### PR TITLE
Added video_capture_vlc

### DIFF
--- a/libs.autobuild
+++ b/libs.autobuild
@@ -11,6 +11,7 @@ autotools_package 'drivers/aravis' do |pkg|
 end
 cmake_package 'drivers/camera_aravis'
 
+cmake_package 'drivers/video_capture_vlc'
 cmake_package 'drivers/video_streamer_vlc'
 cmake_package 'external/aruco'
 cmake_package 'external/lemon'


### PR DESCRIPTION
video_capture_vlc is the opposide side of video_streamer_vlc.
It captures streams throught vlc and create Base::Frames out of this.
It can be used for avi-streams but also for web-streams.
