### PR TITLE
Added deserstar driver (orogen and driver)

### DIFF
--- a/libs.autobuild
+++ b/libs.autobuild
@@ -2,6 +2,7 @@
 
 cmake_package 'external/sbpl'
 cmake_package 'external/ompl'
+cmake_package 'drivers/dps_desertstar_ssp1'
 
 autotools_package 'drivers/aravis' do |pkg|
     pkg.depends_on 'gobject-introspection'

--- a/orogen.autobuild
+++ b/orogen.autobuild
@@ -1,6 +1,7 @@
 # IMPORTANT: new packages must be added at the top of this file (after if
 # package_enabled ...)
 
+    orogen_package 'drivers/orogen/dps_desertstar_ssp1'
     orogen_package 'drivers/orogen/camera_aravis'
     orogen_package 'multiagent/orogen/fipa_services'
     orogen_package 'slam/orogen/gmapping'

--- a/source.yml
+++ b/source.yml
@@ -265,10 +265,10 @@ version_control:
         patches: $AUTOPROJ_SOURCE_DIR/patches/aravis.patch
 
     # Packages that have been migrated to github
-    - drivers/(sonar_tritech):
+    - drivers/(sonar_tritech|dps_desertstar_ssp1):
         github: rock-drivers/drivers-$PACKAGE_BASENAME
         branch: $ROCK_FLAVOR
-    - drivers/orogen/(sonar_tritech):
+    - drivers/orogen/(sonar_tritech|dps_desertstar_ssp1):
         github: rock-drivers/drivers-orogen-$PACKAGE_BASENAME
         branch: $ROCK_FLAVOR
 


### PR DESCRIPTION
This is a test at the same thime to see if github can handle pull-requests based on pull-requests.
The core-part is my commit for the desertstar. Sylvains is a pull-request https://github.com/rock-core/rock-package_set/pull/9 this PR should dissappear here after a merge.
