### PR TITLE
Fixed ffmpeg osdep for jessei and 14.10

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -8,7 +8,7 @@ flann:
 ffmpeg:
     ubuntu: 
         '9.04,9.10,10.04': [libavcodec52, libavdevice52, libavformat52, libswscale0, libavdevice-dev, libavcodec-dev, libavformat-dev, libswscale-dev, libavutil-dev]
-        '11.04,11.10,12.04,12.10,13.04,13.10': [libavcodec53, libavdevice53, libavformat53, libswscale2, libavdevice-dev, libavcodec-dev, libavformat-dev, libswscale-dev, libavutil-dev]
+        '10.10,11.04,11.10,12.04,12.10,13.04,13.10': [libavcodec53, libavdevice53, libavformat53, libswscale2, libavdevice-dev, libavcodec-dev, libavformat-dev, libswscale-dev, libavutil-dev]
         '14.04': [libavcodec54, libavdevice53, libavformat54, libswscale2, libavdevice-dev, libavcodec-dev, libavformat-dev, libswscale-dev, libavutil-dev]
         default: [libavcodec56, libavdevice55, libavformat56, libswscale3, libavdevice-dev, libavcodec-dev, libavformat-dev, libswscale-dev, libavutil-dev]
     debian: 


### PR DESCRIPTION
defaults are now the most actual versions in supported OSes.

debian jessie (testing) is the only supppoted version, replaced jessie
entry with default
