### PR TITLE
orocos kdl moved to github

### DIFF
--- a/source.yml
+++ b/source.yml
@@ -170,8 +170,8 @@ version_control:
     - control/kdl:
         type: git
         branch: master
-        url: http://git.mech.kuleuven.be/robotics/orocos_kinematics_dynamics.git
-        push_to: http://git.mech.kuleuven.be/robotics/orocos_kinematics_dynamics.git
+        url: https://github.com/orocos/orocos_kinematics_dynamics.git
+        push_to: https://github.com/orocos/orocos_kinematics_dynamics.git
         patches:
             - $AUTOPROJ_SOURCE_DIR/patches/orocos_kdl.patch
             - [$AUTOPROJ_SOURCE_DIR/patches/orocos_kdl_eigen_v2.patch, 1]


### PR DESCRIPTION
git.mech.kuleuven.be is unreachable, the new github URL is liked from the official homepage