### PR TITLE
Add dependencies for bzip2

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -405,3 +405,6 @@ flex:
 
 gawk:
     debian,ubuntu: gawk
+
+bzip2:
+    debian,ubuntu: libbz2-dev


### PR DESCRIPTION
This dependency is required for the planning libaries fd_cedalion and fd_uniform