### PR TITLE
Migrate multiagent packages from gitorious to github

### DIFF
--- a/source.yml
+++ b/source.yml
@@ -81,11 +81,11 @@ version_control:
         branch: $ROCK_BRANCH
     
     - multiagent/.*:
-        gitorious: rock-multiagent/$PACKAGE_BASENAME
+        github: rock-multiagent/multiagent-$PACKAGE_BASENAME
         branch: $ROCK_BRANCH
 
     - multiagent/orogen/.*:
-        gitorious: rock-multiagent/orogen-$PACKAGE_BASENAME
+        github: rock-multiagent/multiagent-orogen-$PACKAGE_BASENAME
         branch: $ROCK_BRANCH
 
     - external/yaml-cpp:


### PR DESCRIPTION
Multiagent packages have been moved from github to gitorious. This updates the source definition.