### PR TITLE
Moves motion_planning_libraries lib and module from gitorious to github.

### DIFF
--- a/source.yml
+++ b/source.yml
@@ -36,14 +36,6 @@ version_control:
     - planning/orogen/.*:
         gitorious: rock-planning/orogen-$PACKAGE_BASENAME
         branch: $ROCK_BRANCH
-        
-    - planning/motion_planning_libraries:
-        github: rock-planning/planning-$PACKAGE_BASENAME
-        branch: $ROCK_BRANCH
-
-    - planning/orogen/motion_planning_libraries:
-        github: rock-planning/planning-orogen-$PACKAGE_BASENAME
-        branch: $ROCK_BRANCH
 
     - simulation/imumodel:
         gitorious: rock-simulation/$PACKAGE_BASENAME
@@ -355,6 +347,12 @@ version_control:
         github: rock-planning/planning-$PACKAGE_BASENAME
         branch: $ROCK_BRANCH
     - planning/orogen/pddl_planner:
+        github: rock-planning/planning-orogen-$PACKAGE_BASENAME
+        branch: $ROCK_BRANCH
+    - planning/motion_planning_libraries:
+        github: rock-planning/planning-$PACKAGE_BASENAME
+        branch: $ROCK_BRANCH
+    - planning/orogen/motion_planning_libraries:
         github: rock-planning/planning-orogen-$PACKAGE_BASENAME
         branch: $ROCK_BRANCH
 

--- a/source.yml
+++ b/source.yml
@@ -36,6 +36,14 @@ version_control:
     - planning/orogen/.*:
         gitorious: rock-planning/orogen-$PACKAGE_BASENAME
         branch: $ROCK_BRANCH
+        
+    - planning/motion_planning_libraries:
+        github: rock-planning/planning-$PACKAGE_BASENAME
+        branch: $ROCK_BRANCH
+
+    - planning/orogen/motion_planning_libraries:
+        github: rock-planning/planning-orogen-$PACKAGE_BASENAME
+        branch: $ROCK_BRANCH
 
     - simulation/imumodel:
         gitorious: rock-simulation/$PACKAGE_BASENAME


### PR DESCRIPTION
motion_planning_libraries has been moved to GitHub, just adds the sources. Already tested.