### PR TITLE
prevent ompl from spawning browser to register

### DIFF
--- a/libs.autobuild
+++ b/libs.autobuild
@@ -98,7 +98,11 @@ in_flavor 'master', 'stable' do
     end
     cmake_package 'slam/mtk'
     cmake_package 'external/sbpl'
-    cmake_package 'external/ompl'
+    cmake_package 'external/ompl' do |pkg|
+        # this will prevent the ompl-CMakeLists from spawning a browser to
+        # register...
+        pkg.define("OMPL_REGISTRATION","Off")
+    end
     cmake_package 'external/aruco'
     cmake_package 'external/lemon'
     cmake_package 'external/snap' do |pkg|


### PR DESCRIPTION
This is at least annoying. Slows down bootstrap. Might be bad on a headless system.

Signed-off-by: Martin Zenzes <martin.zenzes@dfki.de>