### PR TITLE
Swichtes sbpl to a forked repository until the sbpl-pull-request is done

### DIFF
--- a/source.yml
+++ b/source.yml
@@ -276,7 +276,7 @@ version_control:
       
     - external/sbpl:
       type: git
-      url: https://github.com/sbpl/sbpl.git
+      url: https://github.com/shoppel/sbpl.git
       
     - external/ompl:
       type: archive


### PR DESCRIPTION
motion_planning_libraries requires an extended sbpl library