### PR TITLE
Revert "added dependency of 'external/aruco' to 'external/opencv'"

### DIFF
--- a/libs.autobuild
+++ b/libs.autobuild
@@ -105,9 +105,7 @@ in_flavor 'master', 'stable' do
         # register...
         pkg.define("OMPL_REGISTRATION","Off")
     end
-    cmake_package 'external/aruco' do |pkg|
-        pkg.depends_on 'external/opencv'
-    end
+    cmake_package 'external/aruco'
     cmake_package 'external/lemon'
     cmake_package 'external/snap' do |pkg|
         pkg.depends_on 'base/cmake'


### PR DESCRIPTION
Reverts rock-core/rock-package_set#44

This makes no sense. One should add a dependency on 'opencv' (the osdep) instead of explicitely referring to external/opencv (the source package)