### PR TITLE
Adds motion_planning_libraries to the new release

### DIFF
--- a/libs.autobuild
+++ b/libs.autobuild
@@ -13,7 +13,6 @@ cmake_package 'gui/pose3d_editor'
 
 in_flavor 'master' do
     cmake_package 'multiagent/fipa_services'
-    cmake_package 'planning/motion_planning_libraries'
     cmake_package 'slam/ceres_solver'
 
     bundle_package 'bundles/rock_auv'
@@ -381,6 +380,7 @@ in_flavor 'master', 'stable' do
     cmake_package 'planning/corridor_planner'
     cmake_package 'planning/vfh_star'
     cmake_package 'planning/corridor_navigation'
+    cmake_package 'planning/motion_planning_libraries'
 
     ##### Localisation and Mapping related packages
     autotools_package 'external/libply' do |pkg|

--- a/orogen.autobuild
+++ b/orogen.autobuild
@@ -5,7 +5,6 @@
     in_flavor 'master' do
         orogen_package 'multiagent/orogen/fipa_services'
         orogen_package 'slam/orogen/gmapping'
-        orogen_package 'planning/orogen/motion_planning_libraries'
         orogen_package 'image_processing/orogen/projection'
         orogen_package 'image_processing/orogen/virtual_view'
         orogen_package 'control/orogen/trajectory_generation'
@@ -118,6 +117,8 @@
         orogen_package 'planning/orogen/corridor_planner' do |pkg|
             pkg.remove_obsolete_installed_file "share", "typelib", "ruby", "corridor_planner.rb"
         end
+        
+        orogen_package 'planning/orogen/motion_planning_libraries'
     end
 
 create_metapackages

--- a/source-stable.yml
+++ b/source-stable.yml
@@ -20,6 +20,6 @@ version_control:
     - slam/octomap:
       tag: 'v1.6.6'
     - external/sbpl:
-      tag: '1.2.0'
+      commit: 5fd7dc8a387cc996ee35678670ac5936ffb333b7 
     - drivers/aravis:
       tag: 'ARAVIS_0_3_6'


### PR DESCRIPTION
The motion_planning_libraries integrates planning libraries like OMPL and SBPL
into Rock. Most work has been done on the SBPL part which allows comfortable
path planning on traversability maps regarding the size and the orientation of the system.
In addition movement types like lateral movements or backward turns can be used.