### PR TITLE
add control/ruby_sdformat

### DIFF
--- a/libs.autobuild
+++ b/libs.autobuild
@@ -145,6 +145,7 @@ in_flavor 'master', 'stable' do
         pkg.depends_on 'base/console_bridge'
     end
     cmake_package 'control/sdformat'
+    ruby_package 'control/ruby_sdformat'
     cmake_package 'control/urdfdom_headers'
     cmake_package 'control/kdl_parser'
     cmake_package 'gui/robot_model'


### PR DESCRIPTION
NOTE: this is do-not-merge as I'll need to create the git repository in rock-control first.

Code is here for now:
  https://github.com/Brazilian-Institute-of-Robotics/tools-ruby_sdf