### PR TITLE
Rock perception

### DIFF
--- a/libs.autobuild
+++ b/libs.autobuild
@@ -21,12 +21,12 @@ in_flavor 'master' do
         pkg.depends_on 'gem-hooks'
         pkg.depends_on 'clang-dev'
     end
-    cmake_package 'image_processing/projection'
+    cmake_package 'perception/projection'
 
     cmake_package 'gui/point_cloud'
     cmake_package 'gui/qcam_calib'
 
-    cmake_package 'image_processing/viso2' do |pkg|
+    cmake_package 'perception/viso2' do |pkg|
         pkg.disable_doc
         pkg.depends_on 'base/cmake'
 
@@ -34,10 +34,10 @@ in_flavor 'master' do
         # directory !
         if pkg.importer.kind_of?(Autobuild::ArchiveImporter) && File.directory?(File.join(pkg.srcdir, ".git"))
             Autoproj.configuration_option "UPDATE_VISO2_FROM_GIT", "boolean",
-                :doc => ["delete image_processing/viso2 to update to a release tarball ?",
+                :doc => ["delete perception/viso2 to update to a release tarball ?",
                     "Rock was previously checking out from a Git repository but just switched to",
                     "using the release tarball. Updating requires the deletion of the",
-                    "currently checked out image_processing/viso2 directory.",
+                    "currently checked out perception/viso2 directory.",
                     "Should I do it ? This is required to continue building"],
                 :default => 'yes'
 
@@ -45,7 +45,7 @@ in_flavor 'master' do
                 Autoproj.warn "deleting Viso2 source directory to migrate from the Git checkout to the release tarball"
                 FileUtils.rm_rf pkg.srcdir
             else
-                raise ConfigError, "user refused to delete image_processing/viso2, aborting the build"
+                raise ConfigError, "user refused to delete perception/viso2, aborting the build"
             end
         end
     end
@@ -371,8 +371,8 @@ in_flavor 'master', 'stable' do
     end
 
     ##### Image Processing
-    cmake_package 'image_processing/stereo'
-    cmake_package 'image_processing/libelas' do |pkg|
+    cmake_package 'perception/stereo'
+    cmake_package 'perception/libelas' do |pkg|
         # Build system from libelas has been patched into a Rock/CMake-based one
         pkg.depends_on 'base/types'
     end

--- a/libs.autobuild
+++ b/libs.autobuild
@@ -22,6 +22,7 @@ in_flavor 'master' do
         pkg.depends_on 'clang-dev'
     end
     cmake_package 'perception/projection'
+    metapackage 'image_processing/projection', 'perception/projection'
 
     cmake_package 'gui/point_cloud'
     cmake_package 'gui/qcam_calib'
@@ -49,6 +50,7 @@ in_flavor 'master' do
             end
         end
     end
+    metapackage 'image_processing/viso2', 'perception/viso2'
 
     cmake_package 'planning/randward'
     cmake_package 'planning/arvand_herd'
@@ -372,10 +374,12 @@ in_flavor 'master', 'stable' do
 
     ##### Image Processing
     cmake_package 'perception/stereo'
+    metapackage 'image_processing/stereo', 'perception/stereo'
     cmake_package 'perception/libelas' do |pkg|
         # Build system from libelas has been patched into a Rock/CMake-based one
         pkg.depends_on 'base/types'
     end
+    metapackage 'image_processing/libelas', 'perception/libelas'
 
     ##### Planning
     cmake_package 'planning/nav_graph_search'

--- a/orogen.autobuild
+++ b/orogen.autobuild
@@ -8,14 +8,18 @@
         orogen_package 'slam/orogen/gmapping'
         orogen_package 'planning/orogen/motion_planning_libraries'
         orogen_package 'perception/orogen/projection'
+        metapackage 'image_processing/orogen/projection', 'perception/orogen/projection'
         orogen_package 'perception/orogen/virtual_view'
+        metapackage 'image_processing/orogen/virtual_view', 'perception/orogen/virtual_view'
         orogen_package 'control/orogen/trajectory_generation'
         orogen_package 'control/orogen/cart_ctrl_wdls'
 
         not_on %w{ubuntu 10.04}, %w{ubuntu 10.10}, %w{ubuntu 11.04}, %w{ubuntu 11.10} do
             orogen_package 'perception/orogen/video_streamer'
+            metapackage 'image_processing/orogen/video_streamer', 'perception/orogen/video_streamer'
         end
         orogen_package 'perception/orogen/viso2'
+        metapackage 'image_processing/orogen/viso2', 'perception/orogen/viso2'
 
 	orogen_package 'control/orogen/torque_estimator'
 
@@ -112,7 +116,9 @@
     	orogen_package 'slam/orogen/tilt_scan'
 
         orogen_package 'perception/orogen/image_preprocessing'
+        metapackage 'image_processing/orogen/image_preprocessing', 'perception/orogen/image_preprocessing'
         orogen_package 'perception/orogen/stereo'
+        metapackage 'image_processing/orogen/stereo', 'perception/orogen/stereo'
 
 	orogen_package 'planning/orogen/corridor_navigation'
         orogen_package 'planning/orogen/corridor_planner' do |pkg|

--- a/orogen.autobuild
+++ b/orogen.autobuild
@@ -7,15 +7,15 @@
         orogen_package 'multiagent/orogen/fipa_services'
         orogen_package 'slam/orogen/gmapping'
         orogen_package 'planning/orogen/motion_planning_libraries'
-        orogen_package 'image_processing/orogen/projection'
-        orogen_package 'image_processing/orogen/virtual_view'
+        orogen_package 'perception/orogen/projection'
+        orogen_package 'perception/orogen/virtual_view'
         orogen_package 'control/orogen/trajectory_generation'
         orogen_package 'control/orogen/cart_ctrl_wdls'
 
         not_on %w{ubuntu 10.04}, %w{ubuntu 10.10}, %w{ubuntu 11.04}, %w{ubuntu 11.10} do
-            orogen_package 'image_processing/orogen/video_streamer'
+            orogen_package 'perception/orogen/video_streamer'
         end
-        orogen_package 'image_processing/orogen/viso2'
+        orogen_package 'perception/orogen/viso2'
 
 	orogen_package 'control/orogen/torque_estimator'
 
@@ -111,8 +111,8 @@
     	orogen_package 'slam/orogen/odometry'
     	orogen_package 'slam/orogen/tilt_scan'
 
-        orogen_package 'image_processing/orogen/image_preprocessing'
-        orogen_package 'image_processing/orogen/stereo'
+        orogen_package 'perception/orogen/image_preprocessing'
+        orogen_package 'perception/orogen/stereo'
 
 	orogen_package 'planning/orogen/corridor_navigation'
         orogen_package 'planning/orogen/corridor_planner' do |pkg|

--- a/source.yml
+++ b/source.yml
@@ -79,11 +79,11 @@ version_control:
         branch: master
       
     - perception/.*:
-        github: rock-image-processing/perception-$PACKAGE_BASENAME
+        github: rock-perception/perception-$PACKAGE_BASENAME
         branch: $ROCK_BRANCH
 
     - perception/orogen/.*:
-        github: rock-image-processing/perception-orogen-$PACKAGE_BASENAME
+        github: rock-perception/perception-orogen-$PACKAGE_BASENAME
         branch: $ROCK_BRANCH
     
     - multiagent/.*:

--- a/source.yml
+++ b/source.yml
@@ -78,12 +78,12 @@ version_control:
     - gui/ffmpeg-ruby:
         branch: master
       
-    - image_processing/.*:
-        github: rock-image-processing/image_processing-$PACKAGE_BASENAME
+    - perception/.*:
+        github: rock-image-processing/perception-$PACKAGE_BASENAME
         branch: $ROCK_BRANCH
 
-    - image_processing/orogen/.*:
-        github: rock-image-processing/image_processing-orogen-$PACKAGE_BASENAME
+    - perception/orogen/.*:
+        github: rock-image-processing/perception-orogen-$PACKAGE_BASENAME
         branch: $ROCK_BRANCH
     
     - multiagent/.*:
@@ -240,7 +240,7 @@ version_control:
         patches:
             - [$AUTOPROJ_SOURCE_DIR/patches/gsf-cmake.patch, 1]
 
-    - image_processing/viso2:
+    - perception/viso2:
         type: archive
         url: http://www.cvlibs.net/downloads/libviso2.zip
         no_subdirectory: true


### PR DESCRIPTION
It aims to rename image_processing to perception. Discussed in the rock-dev mailing list email.

Pros: 
1. To avoid two names:  image_processing (folder) and image-processing (github) -> perception
2. laser filters (e.g. remove an area wrt sensor or body-frame), object recognition and segmentation and ,why not, pcl library (currently is under slam) would have a place in rock.
3. In general everything related to sensing the environment (camera, radar, lidar, tof, etc...) but not building a map.

Cons: 
1. Renaming 

The pull request has two commits:
jhidalgocarrio@24b628eaaf1cd8b2ea307c43c69f248fd50cb147 affect folders and repositories
jhidalgocarrio@dc23a90e23b500f77fb7c290f151f7a8b6db9bed  affects the renaming of the working-group rock-image-processing

This pull request should be done together with  https://github.com/rock-core/package_set/pull/40

Any suggestion how to proceed forward with this?