### PR TITLE
Add arch linux osdep for qwt5

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -177,6 +177,7 @@ qwt5:
     debian,ubuntu: libqwt5-qt4-dev
     fedora,opensuse: qwt-devel
     macos-brew: qwt
+    arch: qwt5
 
 qsqlite:
     debian,ubuntu: libqt4-sql-sqlite


### PR DESCRIPTION
The qwt libs are called qwt5 on Arch Linux.