### PR TITLE
Build kdl library as release

### DIFF
--- a/libs.autobuild
+++ b/libs.autobuild
@@ -192,6 +192,7 @@ in_flavor 'master', 'stable' do
 
     bundle_package 'bundles/rock_ugv_nav'
     cmake_package 'control/kdl' do |pkg|
+        pkg.define("CMAKE_BUILD_TYPE","Release")
         pkg.depends_on 'base/types'
         pkg.with_doc 'docs'
         pkg.doc_dir = File.join('orocos_kdl', 'doc', 'api', 'html')

--- a/libs.autobuild
+++ b/libs.autobuild
@@ -297,7 +297,6 @@ in_flavor 'master', 'stable' do
 
     bundle_package 'bundles/rock_ugv_nav'
     cmake_package 'control/kdl' do |pkg|
-        pkg.define("CMAKE_BUILD_TYPE","Release")
         pkg.depends_on 'base/types'
         pkg.with_doc 'docs'
         pkg.doc_dir = File.join('orocos_kdl', 'doc', 'api', 'html')

--- a/manifests/control/kdl.xml
+++ b/manifests/control/kdl.xml
@@ -9,6 +9,7 @@ Library (KDL), distributed by the Orocos Project.
 
 <rosdep name="pkg-config"/>
 <rosdep name="eigen3"/>
+<tags>stable</tags>
 
 </package>
 

--- a/manifests/control/reflexxes.xml
+++ b/manifests/control/reflexxes.xml
@@ -10,4 +10,5 @@
   <license>LGPL V3.0</license>
   <url>http://www.reflexxes.com</url>
   <depend package="base/cmake" />
+  <tags>stable</tags>
 </package>


### PR DESCRIPTION
The external library KDL should be built as release by default. It is stable for years now.