### PR TITLE
changed gmapping source repo to ros openslam_gmapping, adapted patch

### DIFF
--- a/patches/gmapping.patch
+++ b/patches/gmapping.patch
@@ -1,40 +1,58 @@
-diff -rupN ../gmapping_svn/CMakeLists.txt ./CMakeLists.txt
---- ../gmapping_svn/CMakeLists.txt	1970-01-01 01:00:00.000000000 +0100
-+++ ./CMakeLists.txt	2014-03-18 16:01:09.584648625 +0100
-@@ -0,0 +1,30 @@
-+PROJECT(gmapping)
-+CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
-+
-+ADD_DEFINITIONS(-DLINUX)
-+SET(BUILD_SHARED_LIBS ON)
-+
-+INCLUDE_DIRECTORIES(./)
-+ADD_SUBDIRECTORY(gridfastslam)
-+ADD_SUBDIRECTORY(scanmatcher)
-+ADD_SUBDIRECTORY(sensor)
-+ADD_SUBDIRECTORY(utils)
-+
-+INSTALL(DIRECTORY gridfastslam 
-+                  scanmatcher 
-+                  sensor
-+                  utils
-+                  particlefilter
-+                  log
-+                  grid
-+    DESTINATION include/gmapping/
-+    FILES_MATCHING
-+    PATTERN "*.h"
-+    PATTERN "*.hxx"
-+    PATTERN "*.hpp"
-+    PATTERN ".svn" EXCLUDE)
+From 6e198d8814740c67169b1553840850db8d6b160a Mon Sep 17 00:00:00 2001
+From: Leif Christensen <leif.christensen@dfki.de>
+Date: Fri, 28 Aug 2015 16:56:24 +0200
+Subject: [PATCH] catkin -> rock cmake and pkg-config
+
+---
+ CMakeLists.txt                        | 16 +++++++---------
+ gmapping.pc.in                        | 11 +++++++++++
+ gridfastslam/CMakeLists.txt           |  2 +-
+ scanmatcher/CMakeLists.txt            |  2 +-
+ sensor/sensor_base/CMakeLists.txt     |  2 +-
+ sensor/sensor_odometry/CMakeLists.txt |  2 +-
+ sensor/sensor_range/CMakeLists.txt    |  2 +-
+ utils/CMakeLists.txt                  |  2 +-
+ 8 files changed, 24 insertions(+), 15 deletions(-)
+ create mode 100644 gmapping.pc.in
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4a594d6..9003b70 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,12 +1,6 @@
+ cmake_minimum_required(VERSION 2.8)
+-project(openslam_gmapping)
+-
+-find_package(catkin)
+-
+-catkin_package(
+-  INCLUDE_DIRS include
+-  LIBRARIES gridfastslam scanmatcher sensor_base sensor_range sensor_odometry utils
+-)
++find_package(Rock)
++rock_init(gmapping 0.1)
+ 
+ include_directories(include)
+ 
+@@ -16,8 +10,12 @@ add_subdirectory(sensor)
+ add_subdirectory(utils)
+ 
+ install(DIRECTORY include/
+-  DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
++  DESTINATION include
+   FILES_MATCHING PATTERN "*.h"
+                  PATTERN "*.hxx"
+   PATTERN ".svn" EXCLUDE
+ )
 +
 +SET(PC_FILE ${CMAKE_BINARY_DIR}/gmapping.pc)
 +CONFIGURE_FILE("gmapping.pc.in" ${PC_FILE} @ONLY)
 +INSTALL(FILES ${PC_FILE} DESTINATION lib/pkgconfig)
-+
-diff -rupN ../gmapping_svn/gmapping.pc.in ./gmapping.pc.in
---- ../gmapping_svn/gmapping.pc.in	1970-01-01 01:00:00.000000000 +0100
-+++ ./gmapping.pc.in	2014-03-18 11:22:45.072924000 +0100
+diff --git a/gmapping.pc.in b/gmapping.pc.in
+new file mode 100644
+index 0000000..47bf752
+--- /dev/null
++++ b/gmapping.pc.in
 @@ -0,0 +1,11 @@
 +prefix=@CMAKE_INSTALL_PREFIX@
 +exec_prefix=@CMAKE_INSTALL_PREFIX@
@@ -47,60 +65,64 @@ diff -rupN ../gmapping_svn/gmapping.pc.in ./gmapping.pc.in
 +Version: @PROJECT_VERSION@
 +Libs: -L${libdir} -lgridfastslam -lscanmatcher -lsensor_base -lsensor_odometry -lsensor_range -lutils
 +Cflags: -I${includedir}
-diff -rupN ../gmapping_svn/gridfastslam/CMakeLists.txt ./gridfastslam/CMakeLists.txt
---- ../gmapping_svn/gridfastslam/CMakeLists.txt	1970-01-01 01:00:00.000000000 +0100
-+++ ./gridfastslam/CMakeLists.txt	2014-03-17 18:19:30.545938172 +0100
-@@ -0,0 +1,9 @@
-+ADD_LIBRARY(gridfastslam
-+      gfsreader.cpp
-+      gridslamprocessor.cpp
-+      gridslamprocessor_tree.cpp
-+      motionmodel.cpp
-+)
-+
-+TARGET_LINK_LIBRARIES(gridfastslam scanmatcher sensor_range)
-+INSTALL(TARGETS gridfastslam DESTINATION lib)
-diff -rupN ../gmapping_svn/scanmatcher/CMakeLists.txt ./scanmatcher/CMakeLists.txt
---- ../gmapping_svn/scanmatcher/CMakeLists.txt	1970-01-01 01:00:00.000000000 +0100
-+++ ./scanmatcher/CMakeLists.txt	2014-03-18 11:02:27.660944546 +0100
-@@ -0,0 +1,4 @@
-+add_library(scanmatcher eig3.cpp scanmatcher.cpp scanmatcherprocessor.cpp smmap.cpp)
-+target_link_libraries(scanmatcher sensor_range utils)
-+INSTALL(TARGETS scanmatcher DESTINATION lib)
-+
-diff -rupN ../gmapping_svn/sensor/CMakeLists.txt ./sensor/CMakeLists.txt
---- ../gmapping_svn/sensor/CMakeLists.txt	1970-01-01 01:00:00.000000000 +0100
-+++ ./sensor/CMakeLists.txt	2014-03-11 17:02:28.346499513 +0100
-@@ -0,0 +1,3 @@
-+add_subdirectory(sensor_base)
-+add_subdirectory(sensor_range)
-+add_subdirectory(sensor_odometry)
-diff -rupN ../gmapping_svn/sensor/sensor_base/CMakeLists.txt ./sensor/sensor_base/CMakeLists.txt
---- ../gmapping_svn/sensor/sensor_base/CMakeLists.txt	1970-01-01 01:00:00.000000000 +0100
-+++ ./sensor/sensor_base/CMakeLists.txt	2014-03-18 10:57:47.792949167 +0100
-@@ -0,0 +1,3 @@
-+include_directories(./)
-+add_library(sensor_base sensor.cpp sensorreading.cpp)
-+INSTALL(TARGETS sensor_base DESTINATION lib)
-diff -rupN ../gmapping_svn/sensor/sensor_odometry/CMakeLists.txt ./sensor/sensor_odometry/CMakeLists.txt
---- ../gmapping_svn/sensor/sensor_odometry/CMakeLists.txt	1970-01-01 01:00:00.000000000 +0100
-+++ ./sensor/sensor_odometry/CMakeLists.txt	2014-03-18 10:58:10.852948786 +0100
-@@ -0,0 +1,3 @@
-+add_library(sensor_odometry odometryreading.cpp odometrysensor.cpp)
-+target_link_libraries(sensor_odometry sensor_base)
-+INSTALL(TARGETS sensor_odometry DESTINATION lib)
-diff -rupN ../gmapping_svn/sensor/sensor_range/CMakeLists.txt ./sensor/sensor_range/CMakeLists.txt
---- ../gmapping_svn/sensor/sensor_range/CMakeLists.txt	1970-01-01 01:00:00.000000000 +0100
-+++ ./sensor/sensor_range/CMakeLists.txt	2014-03-18 10:58:38.068948337 +0100
-@@ -0,0 +1,3 @@
-+add_library(sensor_range rangereading.cpp rangesensor.cpp)
-+target_link_libraries(sensor_range sensor_base)
-+INSTALL(TARGETS sensor_range DESTINATION lib)
-Binary files ../gmapping_svn/.svn/wc.db and ./.svn/wc.db differ
-diff -rupN ../gmapping_svn/utils/CMakeLists.txt ./utils/CMakeLists.txt
---- ../gmapping_svn/utils/CMakeLists.txt	1970-01-01 01:00:00.000000000 +0100
-+++ ./utils/CMakeLists.txt	2014-03-18 10:57:05.824949860 +0100
-@@ -0,0 +1,3 @@
-+include_directories(./)
-+add_library(utils movement.cpp stat.cpp)
-+INSTALL(TARGETS utils DESTINATION lib)
+diff --git a/gridfastslam/CMakeLists.txt b/gridfastslam/CMakeLists.txt
+index b3e7f24..b433eaa 100644
+--- a/gridfastslam/CMakeLists.txt
++++ b/gridfastslam/CMakeLists.txt
+@@ -6,4 +6,4 @@ add_library(gridfastslam
+ )
+ target_link_libraries(gridfastslam scanmatcher sensor_range)
+ 
+-install(TARGETS gridfastslam DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
++install(TARGETS gridfastslam DESTINATION lib)
+diff --git a/scanmatcher/CMakeLists.txt b/scanmatcher/CMakeLists.txt
+index 64c1d2f..dbcd80f 100644
+--- a/scanmatcher/CMakeLists.txt
++++ b/scanmatcher/CMakeLists.txt
+@@ -1,4 +1,4 @@
+ add_library(scanmatcher eig3.cpp scanmatcher.cpp scanmatcherprocessor.cpp smmap.cpp)
+ target_link_libraries(scanmatcher sensor_range utils)
+ 
+-install(TARGETS scanmatcher DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
++install(TARGETS scanmatcher DESTINATION lib) 
+diff --git a/sensor/sensor_base/CMakeLists.txt b/sensor/sensor_base/CMakeLists.txt
+index e0317d8..7e34fa3 100644
+--- a/sensor/sensor_base/CMakeLists.txt
++++ b/sensor/sensor_base/CMakeLists.txt
+@@ -1,3 +1,3 @@
+ include_directories(./)
+ add_library(sensor_base sensor.cpp sensorreading.cpp)
+-install(TARGETS sensor_base DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
++install(TARGETS sensor_base DESTINATION lib)
+diff --git a/sensor/sensor_odometry/CMakeLists.txt b/sensor/sensor_odometry/CMakeLists.txt
+index 55adc26..109d6b8 100644
+--- a/sensor/sensor_odometry/CMakeLists.txt
++++ b/sensor/sensor_odometry/CMakeLists.txt
+@@ -1,4 +1,4 @@
+ add_library(sensor_odometry odometryreading.cpp odometrysensor.cpp)
+ target_link_libraries(sensor_odometry sensor_base)
+ 
+-install(TARGETS sensor_odometry DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
++install(TARGETS sensor_odometry DESTINATION lib)
+diff --git a/sensor/sensor_range/CMakeLists.txt b/sensor/sensor_range/CMakeLists.txt
+index 95444bb..16fd41f 100644
+--- a/sensor/sensor_range/CMakeLists.txt
++++ b/sensor/sensor_range/CMakeLists.txt
+@@ -1,4 +1,4 @@
+ add_library(sensor_range rangereading.cpp rangesensor.cpp)
+ target_link_libraries(sensor_range sensor_base)
+ 
+-install(TARGETS sensor_range DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
++install(TARGETS sensor_range DESTINATION lib)
+diff --git a/utils/CMakeLists.txt b/utils/CMakeLists.txt
+index b9e3899..a7d42c8 100644
+--- a/utils/CMakeLists.txt
++++ b/utils/CMakeLists.txt
+@@ -1,3 +1,3 @@
+ include_directories(./)
+ add_library(utils movement.cpp stat.cpp)
+-install(TARGETS utils DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
++install(TARGETS utils DESTINATION lib)
+-- 
+1.9.1
+

--- a/source.yml
+++ b/source.yml
@@ -129,9 +129,10 @@ version_control:
         update_cached_file: false
 
     - slam/gmapping:
-        type: svn
-        url: http://svn.openslam.org/data/svn/gmapping/trunk
-        patches: $AUTOPROJ_SOURCE_DIR/patches/gmapping.patch
+        github: ros-perception/openslam_gmapping.git
+        branch: master
+        patches:
+            - $AUTOPROJ_SOURCE_DIR/patches/gmapping.patch
 
     - slam/hogman:
         type: svn


### PR DESCRIPTION
the source for gmapping that is used in ROS has some (a lot of) fixes, that are not in the original openslam repo, so adapted source.yml to that. Also changed the patch to remove catkin-related stuff.