### PR TITLE
The gem for net-ssh has to be of version <=2.10

### DIFF
--- a/rock.osdeps-ruby19
+++ b/rock.osdeps-ruby19
@@ -1,0 +1,4 @@
+net-ssh: 
+    gem: "net-ssh<=2.10"
+net-scp: 
+    gem: "net-scp<=1.0.4"


### PR DESCRIPTION
In relation to this discussion:
https://github.com/rock-core/rock-package_set/issues/83

and this previous pull request:
https://github.com/rock-core/rock-package_set/pull/85