### PR TITLE
Removed ceres_solver

### DIFF
--- a/libs.autobuild
+++ b/libs.autobuild
@@ -120,7 +120,8 @@ end
 
 in_flavor 'master' do
     cmake_package 'multiagent/fipa_services'
-    cmake_package 'slam/ceres_solver'
+    #Does not compile and maintainer does not respond
+    #cmake_package 'slam/ceres_solver'
 
     bundle_package 'bundles/rock_auv'
     ruby_package 'tools/rbind' do |pkg|


### PR DESCRIPTION
The pacakge does not build scince weeks becasue a patch could not be applied.
The maintainers does not respond, therefore i remove the package now, to
get the rock-all build passed and the HP generated