### PR TITLE
do not include "graphviz" in the rock.osdeps

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -113,13 +113,6 @@ doxygen:
     fedora,opensuse: doxygen
     arch,manjarolinux: doxygen
 
-graphviz:
-    debian,ubuntu: [ graphviz, graphviz-dev ]
-    gentoo: graphviz
-    fedora: [ graphviz, graphviz-devel ]
-    arch,manjarolinux: graphviz
-    opensuse: graphviz-devel
-
 net-ssh: gem
 net-scp: gem
 


### PR DESCRIPTION
looks like graphviz is already declared in orocos-toolchain, see https://github.com/orocos-toolchain/autoproj/blob/master/orocos.osdeps#L89

this will remove the following warning during update:

>  WARN: osdeps definition for graphviz, previously defined in .remotes/github__orocos_toolchain_autoproj_git/orocos.osdeps overridden by autoproj/remotes/rock/rock.osdeps

Signed-off-by: Martin Zenzes <martin.zenzes@dfki.de>