### PR TITLE
install boost-system when boost is required

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -94,6 +94,7 @@ boost:
         - libboost-thread-dev
         - libboost-filesystem-dev
         - libboost-iostreams-dev
+        - libboost-system-dev
     gentoo: dev-libs/boost
     fedora,opensuse: boost-devel
     darwin: boost


### PR DESCRIPTION
Some of the other boost libraries implicitely require boost-system
to be installed, which means that the boost-system dependency start
creeping up virtually everywhere in the cmake code.