### PR TITLE
gtsam into rock package_set and new boost modules in a separated manner

### DIFF
--- a/libs.autobuild
+++ b/libs.autobuild
@@ -1,10 +1,15 @@
 # IMPORTANT: new packages must be added at the top of this file
-cmake_package 'slam/gtsam' #Georgia Tech Smooth and Mapping
 cmake_package 'gui/vizkit3d_pcl'
 cmake_package 'perception/apriltags'
 cmake_package 'slam/threed_odometry'
 cmake_package 'gui/pose3d_editor'
 cmake_package 'control/visp'
+
+cmake_package 'slam/gtsam' do |pkg| #Georgia Tech Smooth and Mapping
+    pkg.define 'GTSAM_BUILD_UNSTABLE','OFF'
+    pkg.define 'GTSAM_USE_SYSTEM_EIGEN','ON'
+    pkg.define 'GTSAM_BUILD_TYPE_POSTFIXES','OFF'
+end
 
 ruby_package 'control/ruby_sdformat'
 cmake_package "drivers/glfw" do |pkg|

--- a/manifests/slam/gtsam.xml
+++ b/manifests/slam/gtsam.xml
@@ -6,5 +6,12 @@
   <license>BSD</license>
   <url>https://collab.cc.gatech.edu/borg/gtsam/</url>
   <depend package="base/cmake" />
+  <depend package="eigen3" />
+  <rosdep name="boost" />
+  <rosdep name="boost-timer" />
+  <rosdep name="boost-date-time" />
+  <rosdep name="boost-serialization" />
+  <rosdep name="metis" />
+
   <tags>stable</tags>
 </package>

--- a/patches/gtsam.patch
+++ b/patches/gtsam.patch
@@ -1,13 +1,92 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8c4229e..5ab20aa 100644
 --- ./CMakeLists.txt
 +++ ./CMakeLists.txt
-@@ -207,7 +207,7 @@ endif()
- ### use our patched version of Eigen
- ### See:  http://eigen.tuxfamily.org/bz/show_bug.cgi?id=704 (Householder QR MKL selection)
- ###       http://eigen.tuxfamily.org/bz/show_bug.cgi?id=705 (Fix MKL LLT return code)
--option(GTSAM_USE_SYSTEM_EIGEN "Find and use system-installed Eigen. If 'off', use the one bundled with GTSAM" OFF)
-+option(GTSAM_USE_SYSTEM_EIGEN "Find and use system-installed Eigen. If 'off', use the one bundled with GTSAM" ON)
-
- # Switch for using system Eigen or GTSAM-bundled Eigen
+@@ -225,6 +225,8 @@ option(GTSAM_USE_SYSTEM_EIGEN "Find and use system-installed Eigen. If 'off', us
  if(GTSAM_USE_SYSTEM_EIGEN)
-
+ 	find_package(Eigen3 REQUIRED)
+ 	include_directories(AFTER "${EIGEN3_INCLUDE_DIR}")
++        find_package(LAPACK REQUIRED)
++
+ 
+ 	# Use generic Eigen include paths e.g. <Eigen/Core>
+     set(GTSAM_EIGEN_INCLUDE_PREFIX "${EIGEN3_INCLUDE_DIR}")
+@@ -335,6 +337,10 @@ if(GTSAM_ENABLE_CONSISTENCY_CHECKS)
+   add_definitions(-DGTSAM_EXTRA_CONSISTENCY_CHECKS)
+ endif()
+ 
++if(NOT WIN32)
++    option(GTSAM_BUILD_PKGCONFIG "Build pkg-config .pc file for GTSAM" ON)
++endif(NOT WIN32)
++
+ ###############################################################################
+ # Add components
+ 
+diff --git a/gtsam/CMakeLists.txt b/gtsam/CMakeLists.txt
+index d322942..12280ec 100644
+--- ./gtsam/CMakeLists.txt
++++ ./gtsam/CMakeLists.txt
+@@ -158,3 +158,46 @@ if (GTSAM_INSTALL_MATLAB_TOOLBOX)
+     # Wrap
+     wrap_and_install_library(../gtsam.h "${GTSAM_ADDITIONAL_LIBRARIES}" "" "${mexFlags}")
+ endif ()
++
++macro(libraries_for_pkgconfig VARNAME)
++    foreach(__lib ${ARGN})
++        string(STRIP __lib ${__lib})
++        string(SUBSTRING ${__lib} 0 1 __lib_is_absolute)
++        if (__lib_is_absolute STREQUAL "/")
++            get_filename_component(__lib_path ${__lib} PATH)
++            get_filename_component(__lib_name ${__lib} NAME_WE)
++            string(REGEX REPLACE "^lib" "" __lib_name "${__lib_name}")
++            set(${VARNAME} "${${VARNAME}} -L${__lib_path} -l${__lib_name}")
++        else()
++            set(${VARNAME} "${${VARNAME}} ${__lib}")
++        endif()
++    endforeach()
++endmacro()
++
++# Generate pkgconfig pc file
++if(GTSAM_BUILD_PKGCONFIG)
++    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/gtsam.pc.in)
++        message("-- Found: ${CMAKE_CURRENT_SOURCE_DIR}/gtsam.pc.in")
++
++        # Set the target name
++        set(TARGET_NAME gtsam)
++
++        # Dependency for GTSAM
++        libraries_for_pkgconfig(${TARGET_NAME}_PKGCONFIG_LIBS
++            ${GTSAM_BOOST_LIBRARIES} ${GTSAM_ADDITIONAL_LIBRARIES}
++            ${LAPACK_LIBRARIES})
++
++        set(${TARGET_NAME}_PKGCONFIG_CFLAGS "${${TARGET_NAME}_PKGCONFIG_CFLAGS} ${BOOST_CFLAGS_OTHER}")
++
++        set(PKGCONFIG_REQUIRES eigen3)
++        set(PKGCONFIG_CFLAGS ${${TARGET_NAME}_PKGCONFIG_CFLAGS})
++        set(PKGCONFIG_LIBS ${${TARGET_NAME}_PKGCONFIG_LIBS})
++
++        configure_file(gtsam.pc.in gtsam.pc @ONLY)
++        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/gtsam.pc
++            DESTINATION lib/pkgconfig)
++    else()
++        message("-- pkg-config: ${CMAKE_CURRENT_SOURCE_DIR}/gtsam.pc.in is not available for configuration")
++    endif()
++
++endif(GTSAM_BUILD_PKGCONFIG)
+diff --git a/gtsam/gtsam.pc.in b/gtsam/gtsam.pc.in
+new file mode 100644
+index 0000000..52c3361
+--- /dev/null
++++ ./gtsam/gtsam.pc.in
+@@ -0,0 +1,11 @@
++prefix=@CMAKE_INSTALL_PREFIX@
++exec_prefix=@CMAKE_INSTALL_PREFIX@
++libdir=${prefix}/lib
++includedir=${prefix}/include
++
++Name: @TARGET_NAME@
++Description: @TARGET_NAME@
++Version: @GTSAM_VERSION_STRING@
++Requires: @PKGCONFIG_REQUIRES@
++Libs: -L${libdir} -l@TARGET_NAME@ @PKGCONFIG_LIBS@
++Cflags: -I${includedir} @PKGCONFIG_CFLAGS@

--- a/rock.osdeps
+++ b/rock.osdeps
@@ -102,6 +102,24 @@ boost:
         - boost
         - boost-libs
 
+boost-timer:
+    debian,ubuntu:
+        - libboost-timer-dev
+    gentoo: dev-libs/boost
+    fedora,opensuse: boost-devel
+
+boost-date-time:
+    debian,ubuntu:
+        - libboost-date-time-dev
+    gentoo: dev-libs/boost
+    fedora,opensuse: boost-devel
+
+boost-serialization:
+    debian,ubuntu:
+        - libboost-serialization-dev
+    gentoo: dev-libs/boost
+    fedora,opensuse: boost-devel
+
 ncurses:
     debian,ubuntu: libncurses5-dev
     gentoo: sys-libs/ncurses
@@ -445,4 +463,8 @@ libxml2:
 
 libpcrecpp:
     ubuntu,debian: libpcre3-dev
+
+metis:
+    ubuntu,debian: libmetis-dev
+    gentoo: sci-libs/metis
 

--- a/source.yml
+++ b/source.yml
@@ -241,7 +241,7 @@ version_control:
         push_to: git@bitbucket.org:gtborg/gtsam.git
         push_url: https://bitbucket.org/gtborg/gtsam.git
         repository_id: https://bitbucket.org/gtborg/gtsam.git
-        branch: develop
+        commit: f967a54c708bdf2e04145b87085ea63dae777273
         patches:
             - $AUTOPROJ_SOURCE_DIR/patches/gtsam.patch
 


### PR DESCRIPTION
This PR fixes slam/gtsam update&build with autoproj
It adds the following required os dependencies:
  boost-timer:
  boost-date-time:
  boost-serialization:
  metis:

