### PR TITLE
fix vtk dependency for ubuntu 16.04+

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -234,7 +234,17 @@ dc1394:
     fedora,opensuse: libdc1394-devel
 
 vtk:
-    debian,ubuntu: [ libvtk5-dev, tcl-vtk, python-vtk, libvtk-java ]
+    debian,ubuntu:
+        '14.04,14.10,15.04,15.10':
+            - libvtk5-dev
+            - tcl-vtk
+            - python-vtk
+            - libvtk-java
+        default:
+            - libvtk6-dev
+            - tcl-vtk
+            - python-vtk
+            - libvtk-java
     fedora: [ vtk-devel, vtk-tcl, vtk-python, vtk-java ]
     opensuse: [ vtk-devel, vtk-tcl, python-vtk, python-vtk-qt, vtk-java ]
 


### PR DESCRIPTION
This is **NOT** tested on older ubuntus. Please test before merging.