### PR TITLE
Move external/sbpl and external/ompl to planning folder

### DIFF
--- a/libs.autobuild
+++ b/libs.autobuild
@@ -238,12 +238,14 @@ in_flavor 'master', 'stable' do
         pkg.depends_on 'gtk-doc-tools'
     end
     cmake_package 'slam/mtk'
-    cmake_package 'external/sbpl'
-    cmake_package 'external/ompl' do |pkg|
+    cmake_package 'planning/sbpl'
+    metapackage 'external/sbpl', 'planning/sbpl'
+    cmake_package 'planning/ompl' do |pkg|
         # this will prevent the ompl-CMakeLists from spawning a browser to
         # register...
         pkg.define("OMPL_REGISTRATION","Off")
     end
+    metapackage 'external/ompl', 'planning/ompl'
     cmake_package 'external/aruco' do |pkg|
         pkg.depends_on 'opencv'
     end

--- a/manifests/planning/ompl.xml
+++ b/manifests/planning/ompl.xml
@@ -1,0 +1,13 @@
+<package>
+    <description brief="OMPL">
+      This in an integration package for the Open Motion Planning Library, see
+      url below.  No additional functionality is provided, adaptations to the
+      original source are made only to include the planning library into the
+      build infrastructure.
+  </description>
+  <maintainer>Thomas Roehr/thomas.roehr@dfki.de</maintainer>
+  <license>Modified BSD</license>
+  <url>http://ompl.kavrakilab.org</url>
+  <depend package="boost" />
+  <depend package="flann" optional="1" />
+</package>

--- a/source.yml
+++ b/source.yml
@@ -302,11 +302,11 @@ version_control:
 #      github: rdiankov/openrave
 #      branch: latest_stable
       
-    - external/sbpl:
+    - planning/sbpl:
       type: git
       url: https://github.com/sbpl/sbpl.git
       
-    - external/ompl:
+    - planning/ompl:
       type: archive
       url: https://bitbucket.org/ompl/ompl/downloads/ompl-0.14.0-Source.tar.gz  
 

--- a/source.yml
+++ b/source.yml
@@ -307,8 +307,9 @@ version_control:
       url: https://github.com/sbpl/sbpl.git
       
     - planning/ompl:
-      type: archive
-      url: https://bitbucket.org/ompl/ompl/downloads/ompl-0.14.0-Source.tar.gz  
+      type: git
+      url: https://github.com/ompl/ompl.git
+      tag: 0.14.0
 
     - drivers/aravis:
         type: git


### PR DESCRIPTION
Move the planning libraries to the planning folders and provide a valid manifest.