### PR TITLE
fixed avaris driver source url

### DIFF
--- a/source.yml
+++ b/source.yml
@@ -317,8 +317,7 @@ version_control:
       tag: 0.14.0
 
     - drivers/aravis:
-        type: git
-        url: git://git.gnome.org/aravis
+        github: AravisProject/aravis
         patches: $AUTOPROJ_SOURCE_DIR/patches/aravis.patch
         branch: master
 


### PR DESCRIPTION
git://git.gnome.org/aravis url is not working anymore.

The github url is taken from the original page:
https://wiki.gnome.org/action/show/Projects/Aravis