### PR TITLE
when libvtk6 is used, also python-vtk6 should be used

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -246,7 +246,7 @@ vtk:
         default:
             - libvtk6-dev
             - tcl-vtk
-            - python-vtk
+            - python-vtk6
             - libvtk-java
     fedora: [ vtk-devel, vtk-tcl, vtk-python, vtk-java ]
     opensuse: [ vtk-devel, vtk-tcl, python-vtk, python-vtk-qt, vtk-java ]


### PR DESCRIPTION
python-vtk has a dependency to vtk5 and conflicts with the vtk6 installation