### PR TITLE
Use recent version of planning/ompl: 1.2.1

### DIFF
--- a/patches/ompl_pkgconfig.patch
+++ b/patches/ompl_pkgconfig.patch
@@ -1,0 +1,9 @@
+--- ../ompl_ge_1.1.0/CMakeModules/ompl.pc.in     2016-06-30 12:39:01.109812445 +0200
++++ ./CMakeModules/ompl.pc.in        2016-06-30 12:38:40.157812238 +0200
+@@ -9,4 +9,4 @@
+ Version: @OMPL_VERSION@
+ Requires: @PKG_EXTERNAL_DEPS@
+ Libs: -L${libdir} @PKG_OMPL_LIBS@
+-Cflags: -I${includedir}
++Cflags: -I${includedir} -std=c++11
+

--- a/source.yml
+++ b/source.yml
@@ -324,7 +324,9 @@ version_control:
     - planning/ompl:
       type: git
       url: https://github.com/ompl/ompl.git
-      tag: 0.14.0
+      tag: 1.2.1
+      patches:
+          - $AUTOPROJ_SOURCE_DIR/patches/ompl_pkgconfig.patch
 
     - drivers/aravis:
         github: AravisProject/aravis


### PR DESCRIPTION
This version will require cxx11 and (compared to the previously used version 0.14) and among other changes will use std::shared_ptr instead of boost
