### PR TITLE
Change external/yaml-cpp and yaml-cpp03 to point to github repository

### DIFF
--- a/source.yml
+++ b/source.yml
@@ -110,15 +110,13 @@ version_control:
         branch: master
 
     - external/yaml-cpp:
-        type: archive
-        url: http://yaml-cpp.googlecode.com/files/yaml-cpp-0.3.0.tar.gz
-        update_cached_file: false
+        github: jbeder/yaml-cpp
+        tag: release-0.3.0
 
     - external/yaml-cpp03:
-        type: archive
-        url: http://yaml-cpp.googlecode.com/files/yaml-cpp-0.3.0.tar.gz
+        github: jbeder/yaml-cpp
+        tag: release-0.3.0
         patches: $AUTOPROJ_SOURCE_DIR/patches/yaml-cpp03.patch
-        update_cached_file: false
 
     - slam/pcl:
         github: PointCloudLibrary/pcl


### PR DESCRIPTION
Repositories moved to github and the archives on code.google.com are not available anymore.

rock-users should be notified once this gets merged.