### PR TITLE
Add correct lib name for libqglviewer on 16.04

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -368,6 +368,7 @@ unzip:
 libqglviewer:
     ubuntu:
         '12.04,12.10,13.04': libqglviewer-qt4-dev
+        '16.04': libqglviewer-dev-qt4
         default: libqglviewer-dev
     debian:
         '7.3':   libqglviewer-qt4-dev


### PR DESCRIPTION
On 16.04 libqglviewer-dev installs the qt5 version of qglviewer.
The qt4 version is called libqglviewer-dev-qt4