### PR TITLE
Add gtest and google-mock to rock.osdeps

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -121,6 +121,12 @@ boost-serialization:
     gentoo: dev-libs/boost
     fedora,opensuse: boost-devel
 
+libgtest-dev:
+    debian,ubuntu: libgtest-dev
+
+google-mock:
+    debian,ubuntu: google-mock
+
 ncurses:
     debian,ubuntu: libncurses5-dev
     gentoo: sys-libs/ncurses


### PR DESCRIPTION
This should be merged when [#37](https://github.com/rock-core/base-cmake/pull/37) is merged