### PR TITLE
define ruby-geoutm

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -494,3 +494,6 @@ control/sdformat:
         '14.04,14.10,15.04,15.10': nonexistent
         '16.04': libsdformat4-dev
 
+ruby-geoutm:
+    gem: geoutm
+


### PR DESCRIPTION
Provides support for latlong/utm conversions. Will be used by
control/ruby_sdformat to support SDF's spherical_coordinates
element.