### PR TITLE
Updates the url of drivers/imu_an_spatial

### DIFF
--- a/source.yml
+++ b/source.yml
@@ -352,7 +352,7 @@ version_control:
 
     - drivers/imu_an_spatial:
         type: archive
-        url: http://www.advancednavigation.com.au/sites/advancednavigation.com.au/files/SpatialSDK.zip 
+        url: http://www.advancednavigation.com.au/sites/advancednavigation.com.au/files/spatialsdk.zip
         no_subdirectory: true
         update_cached_file: true
         patches:


### PR DESCRIPTION
New url according to http://www.advancednavigation.com.au/product/spatial#software
The old url does not work anymore: http://www.advancednavigation.com.au/sites/advancednavigation.com.au/files/SpatialSDK.zip