### PR TITLE
Move dependency from GTest to rock.core package set

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -124,12 +124,6 @@ boost-serialization:
     gentoo: dev-libs/boost
     fedora,opensuse: boost-devel
 
-libgtest-dev:
-    debian,ubuntu: libgtest-dev
-
-google-mock:
-    debian,ubuntu: google-mock
-
 ncurses:
     debian,ubuntu: libncurses5-dev
     gentoo: sys-libs/ncurses


### PR DESCRIPTION
With rock-core/drivers-iodrivers_base#20, iodrivers_base test suite would become dependent on GTest (only for the tests). This moves the gtest osdeps from rock to rock.core.

Depends on:
- [x] https://github.com/rock-core/package_set/pull/125