### PR TITLE
add the gps_base packages

### DIFF
--- a/libs.autobuild
+++ b/libs.autobuild
@@ -2,6 +2,7 @@
 bundle_package 'bundles/rock_multiagent'
 cmake_package 'planning/exploration'
 cmake_package 'drivers/imu_an_spatial'
+cmake_package 'drivers/gps_base'
 cmake_package 'gui/vizkit3d_pcl'
 cmake_package 'perception/apriltags'
 cmake_package 'slam/threed_odometry'

--- a/orogen.autobuild
+++ b/orogen.autobuild
@@ -4,6 +4,7 @@
 orogen_package 'drivers/orogen/imu_myahrs_plus'
 orogen_package 'planning/orogen/exploration'
 orogen_package 'drivers/orogen/imu_an_spatial'
+orogen_package 'drivers/orogen/gps_base'
 orogen_package 'slam/orogen/pcl'
 orogen_package 'perception/orogen/apriltags'
 orogen_package 'control/orogen/visp'


### PR DESCRIPTION
The two packages provide basic GNSS-related functionality -- types that were formerly in the mb500 package, and the conversion-to-UTM