### PR TITLE
fix drivers/libusb, drivers/imu_myahrs_plus and drivers/glew to not modify the filesystem in #prepare

### DIFF
--- a/libs.autobuild
+++ b/libs.autobuild
@@ -26,14 +26,6 @@ remove_from_default 'drivers/glfw'
 
 import_package 'drivers/imu_myahrs_plus' do |pkg|
 
-    def pkg.prepare
-        super
-        isolate_errors do
-            build
-            progress_done
-        end
-    end
-
     def pkg.build
         in_dir (File.join(srcdir, "common_cpp")) do
             run("build", Autobuild.tool(:make))
@@ -41,6 +33,10 @@ import_package 'drivers/imu_myahrs_plus' do |pkg|
     end
 
     def pkg.install
+        isolate_errors do
+            build
+            progress_done
+        end
         super
         install_prefix = File.join(prefix, "include", name.split('/')[1])
         FileUtils.mkdir_p install_prefix
@@ -74,17 +70,15 @@ import_package "drivers/glew" do |pkg|
         end
         task "#{name}-build" => buildstamp
         file installstamp => buildstamp
-        
-        Autoproj.env_set_path "GLEW_DEST", prefix
+    end
 
-        in_dir(srcdir) do 
-            run("prepare",Autobuild.tool(:make), 'extensions')
-        end 
+    def pkg.update_environment
+        env_set "GLEW_DEST", prefix
     end
     
     def pkg.build 
-        Autoproj.env_set_path "GLEW_DEST", prefix
         in_dir(srcdir) do 
+            run("build",Autobuild.tool(:make), 'extensions')
             run("build",Autobuild.tool(:make))
         end
     end

--- a/libs.autobuild
+++ b/libs.autobuild
@@ -106,46 +106,11 @@ cmake_package "drivers/freenect2" do |pkg|
 end
 
 #Needed for kinect, the os packages does not (yet) work 06.15 (see patch in this package set)
-import_package 'drivers/libusb' do |pkg|
+autotools_package 'drivers/libusb' do |pkg|
+    pkg.using[:autogen] = 'bootstrap.sh'
+    pkg.configureflags << '--enable-maintainer-mode'
+    pkg.parallel_build_level = 1
     pkg.depends_on "libudev"
-    def pkg.buildstamp; "autobuild-stamp" end
-    def pkg.prepare
-        source_tree srcdir do |pkg2|
-            File.open(File.join(srcdir,".gitignore")).each_line do |excl|
-                pkg2.exclude << Regexp.new("^#{Regexp.quote(excl)}")
-            end
-        end
-
-        super
-
-        stamps = dependencies.map { |pkg2| Autobuild::Package[pkg2].installstamp }
-
-        file buildstamp => stamps do
-            isolate_errors do
-                build
-                progress_done
-            end
-        end
-        task "#{name}-build" => buildstamp
-        file installstamp => buildstamp
-
-        in_dir(srcdir) do
-            run("prepare_bootstrap","./bootstrap.sh")
-            run("prepare_configure","./configure", "--prefix=#{Autobuild.prefix}")
-        end
-    end
-
-    def pkg.build
-        in_dir(srcdir) do
-            run("build", Autobuild.tool(:make))
-        end
-    end
-
-    def pkg.install
-        in_dir(srcdir) do
-            run("install", Autobuild.tool(:make), "install")
-        end
-    end
 end
 
 cmake_package 'gui/collada_dom' do |pkg|


### PR DESCRIPTION
Beyond the merits of writing custom code to handle a standard package,
*NOTHING* that modifies the filesystem should be ever done in the
prepare method of a package.