### PR TITLE
Bypass graphviz and boost package redefinition warning

### DIFF
--- a/overrides.rb
+++ b/overrides.rb
@@ -2,3 +2,23 @@ if rock_toolchain = Autoproj.manifest.find_metapackage('rock.toolchain')
     rock_toolchain.add Autobuild::Package['gui/vizkit']
     rock_toolchain.add Autobuild::Package['bundles/rock']
 end
+
+Autoproj.osdeps.definitions['graphviz'] = Hash.new
+Autoproj.osdeps.definitions['graphviz']['debian,ubuntu'] = ['graphviz', 'graphviz-dev']
+Autoproj.osdeps.definitions['graphviz']['gentoo'] = ['graphviz']
+Autoproj.osdeps.definitions['graphviz']['fedora'] = ['graphviz', 'graphviz-devel']
+Autoproj.osdeps.definitions['graphviz']['arch,manjarolinux'] = ['graphviz']
+Autoproj.osdeps.definitions['graphviz']['opensuse'] = ['graphviz-devel']
+
+Autoproj.osdeps.definitions['boost'] = Hash.new
+Autoproj.osdeps.definitions['boost']['debian,ubuntu'] = ['libboost-dev', 'libboost-graph-dev',
+                                                         'libboost-program-options-dev',
+                                                         'libboost-regex-dev',
+                                                         'libboost-thread-dev',
+                                                         'libboost-filesystem-dev',
+                                                         'libboost-iostreams-dev',
+                                                         'libboost-system-dev']
+Autoproj.osdeps.definitions['boost']['gentoo'] = ['dev-libs/boost']
+Autoproj.osdeps.definitions['boost']['fedora,opensuse'] = ['boost-devel']
+Autoproj.osdeps.definitions['boost']['darwin'] = ['boost']
+Autoproj.osdeps.definitions['boost']['arch,manjarolinux'] = ['boost', 'boost-libs']

--- a/rock.osdeps
+++ b/rock.osdeps
@@ -89,23 +89,6 @@ gpsd:
   arch,manjarolinux: gpsd
   opensuse: gpsd-devel
 
-boost:
-    debian,ubuntu:
-        - libboost-dev
-        - libboost-graph-dev
-        - libboost-program-options-dev
-        - libboost-regex-dev
-        - libboost-thread-dev
-        - libboost-filesystem-dev
-        - libboost-iostreams-dev
-        - libboost-system-dev
-    gentoo: dev-libs/boost
-    fedora,opensuse: boost-devel
-    darwin: boost
-    arch,manjarolinux:
-        - boost
-        - boost-libs
-
 boost-timer:
     debian,ubuntu:
         - libboost-timer-dev
@@ -135,13 +118,6 @@ doxygen:
     gentoo: app-doc/doxygen
     fedora,opensuse: doxygen
     arch,manjarolinux: doxygen
-
-graphviz:
-    debian,ubuntu: [ graphviz, graphviz-dev ]
-    gentoo: graphviz
-    fedora: [ graphviz, graphviz-devel ]
-    arch,manjarolinux: graphviz
-    opensuse: graphviz-devel
 
 net-ssh: gem
 net-scp: gem


### PR DESCRIPTION
I wish there was a better way to do this... :(