### PR TITLE
Fix apriltags patch -- otherwise manifest.xml will be invalid

### DIFF
--- a/patches/apriltags.patch
+++ b/patches/apriltags.patch
@@ -43,7 +43,7 @@ diff -urN ../apriltag-2015-03-18/CMakeLists.txt ./CMakeLists.txt
 diff -urN ../apriltag-2015-03-18/manifest.xml ./manifest.xml
 --- ../apriltag-2015-03-18/manifest.xml	1970-01-01 01:00:00.000000000 +0100
 +++ ./manifest.xml	2015-04-30 17:20:35.639306306 +0200
-@@ -0,0 +1,12 @@
+@@ -0,0 +1,13 @@
 +<package>
 +  <description brief="Apriltags Marker Detection, source file can be find in http://april.eecs.umich.edu/wiki/index.php/AprilTags">
 +  


### PR DESCRIPTION
The current patch leaves out the last closing tag