### PR TITLE
added ubuntu,debian osdep for pypy (currently used by some planning p…

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -528,3 +528,6 @@ geographic:
         '15.10,16.04': libgeographic-dev
         default:       libgeographic-dev
 
+pypy:
+    ubuntu,debian: pypy
+


### PR DESCRIPTION
added ubuntu,debian osdep for pypy (currently used by some planning packages) in the rock package set.

pypy under that package name at least available under ubuntu 16.04, 18.04 and debian jessi(oldstable),
stretch(stable), buster(testing) and sid(unstable)