### PR TITLE
[aruco_from_repo] The zip on the targeted version does not exist anym…

### DIFF
--- a/source.yml
+++ b/source.yml
@@ -305,9 +305,8 @@ version_control:
          - $AUTOPROJ_SOURCE_DIR/patches/gexf_patch_stdout.patch
 
     - external/aruco:
-      type: archive
-      url: https://downloads.sourceforge.net/project/aruco/2.0.19/aruco-2.0.19.zip
-      archive_dir: aruco-2.0.19
+      type: git
+      url: https://github.com/ProtolabSBRE/aruco.git
       patches:
          - $AUTOPROJ_SOURCE_DIR/patches/aruco.patch
 


### PR DESCRIPTION
…ore. Replace the it for a repo.

This might not be the best solution: The repository does not seem to be the official one of the developers. They seem to prefer Sourceforge.

Better option would be to use the newer version offered in SourceForge.