### PR TITLE
define gstreamer-vaapi and gstreamer-plugins-bad

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -289,6 +289,14 @@ gstreamer:
         - libgstreamer-plugins-good1.0-0
     fedora,opensuse: gstreamer-devel
 
+gstreamer-vaapi:
+    ubuntu:
+        - gstreamer1.0-vaapi
+
+gstreamer-plugins-bad:
+    ubuntu:
+        - gstreamer1.0-plugins-bad
+
 libproc:
     debian:
         default: libprocps3-dev


### PR DESCRIPTION
Both are on purpose plugins, that is runtime-only and
not devel packages since GStreamer gives a uniform way
to load and use these plugins.