### PR TITLE
mark gui/robot_model's tests as not available

### DIFF
--- a/libs.autobuild
+++ b/libs.autobuild
@@ -297,7 +297,11 @@ in_flavor 'master', 'stable' do
     cmake_package 'control/urdfdom_headers'
     cmake_package 'control/kdl_parser'
     cmake_package 'control/robot_frames'
-    cmake_package 'gui/robot_model'
+    cmake_package 'gui/robot_model' do |pkg|
+        # the tests in gui/robot_model is an app for a human to run. Do not let
+        # autoproj believe there is something to run automatically
+        pkg.test_utility.available = false
+    end
     cmake_package 'gui/control_ui'
     cmake_package 'control/joint_dispatcher'
     cmake_package 'control/kdl_conversions'


### PR DESCRIPTION
The tests in gui/robot_model is an app for a human to run. Do not let
autoproj believe there is something to run automatically