### PR TITLE
update fetch instructions for external/kdtree

### DIFF
--- a/patches/libkdtree++_0.7.1.diff
+++ b/patches/libkdtree++_0.7.1.diff
@@ -1,0 +1,494 @@
+--- Makefile.in
++++ Makefile.in
+@@ -154,7 +154,6 @@
+ srcdir = @srcdir@
+ sysconfdir = @sysconfdir@
+ target_alias = @target_alias@
+-top_build_prefix = @top_build_prefix@
+ top_builddir = @top_builddir@
+ top_srcdir = @top_srcdir@
+ nobase_include_HEADERS = \
+--- INSTALL
++++ INSTALL
+@@ -2,7 +2,7 @@
+ *************************
+ 
+ Copyright (C) 1994, 1995, 1996, 1999, 2000, 2001, 2002, 2004, 2005,
+-2006 Free Software Foundation, Inc.
++2006, 2007 Free Software Foundation, Inc.
+ 
+ This file is free documentation; the Free Software Foundation gives
+ unlimited permission to copy, distribute and modify it.
+@@ -67,6 +67,9 @@
+      all sorts of other programs in order to regenerate files that came
+      with the distribution.
+ 
++  6. Often, you can also type `make uninstall' to remove the installed
++     files again.
++
+ Compilers and Options
+ =====================
+ 
+--- debian/rules
++++ debian/rules
+@@ -0,0 +1,120 @@
++#!/usr/bin/make -f
++# -*- makefile -*-
++# Sample debian/rules that uses debhelper.
++#
++# This file was originally written by Joey Hess and Craig Small.
++# As a special exception, when this file is copied by dh-make into a
++# dh-make output file, you may use that output file without restriction.
++# This special exception was added by Craig Small in version 0.37 of dh-make.
++#
++# Modified to make a template file for a multi-binary package with separated
++# build-arch and build-indep targets  by Bill Allombert 2001
++
++# Uncomment this to turn on verbose mode.
++#export DH_VERBOSE=1
++
++# This has to be exported to make some magic below work.
++export DH_OPTIONS
++
++
++
++configure: configure-stamp
++configure-stamp:
++	dh_testdir
++	# Add here commands to configure the package.
++	./configure --prefix=/usr
++	touch configure-stamp
++
++
++#Architecture 
++#build: build-arch build-indep
++build: build-indep
++
++#build-arch: build-arch-stamp
++#build-arch-stamp: configure-stamp 
++
++	# Add here commands to compile the arch part of the package.
++	#$(MAKE) 
++#	touch $@
++
++build-indep: build-indep-stamp
++build-indep-stamp: configure-stamp 
++
++	# Add here commands to compile the indep part of the package.
++	#$(MAKE) doc
++	touch $@
++
++clean:
++	dh_testdir
++	dh_testroot
++	rm -f build-arch-stamp build-indep-stamp configure-stamp
++	[ ! -f Makefile ] || [ ! -f config.status ] || $(MAKE) distclean
++	[ ! -f examples/Makefile ] || $(MAKE) -C examples clean
++	rm -f config.status config.log aclocal.m4
++	dh_clean 
++
++install: install-indep install-arch
++install-indep:
++	dh_testdir
++	dh_testroot
++	dh_clean -k -i 
++	dh_installdirs -i
++
++	# Add here commands to install the indep part of the package into
++	# debian/<package>-doc.
++	#INSTALLDOC#
++	$(MAKE) DESTDIR=$(CURDIR)/debian/libkdtree++-dev install
++
++	dh_install -i
++
++install-arch:
++	dh_testdir
++	dh_testroot
++	dh_clean -k -s 
++	dh_installdirs -s
++
++	# Add here commands to install the arch part of the package into 
++	$(MAKE) DESTDIR=$(CURDIR)/debian/libkdtree++-dev install
++
++	dh_install -s
++# Must not depend on anything. This is to be called by
++# binary-arch/binary-indep
++# in another 'make' thread.
++binary-common:
++	dh_testdir
++	dh_testroot
++	dh_installchangelogs 
++	dh_installdocs
++	dh_installexamples
++#	dh_installmenu
++#	dh_installdebconf	
++#	dh_installlogrotate	
++#	dh_installemacsen
++#	dh_installpam
++#	dh_installmime
++#	dh_python
++#	dh_installinit
++#	dh_installcron
++#	dh_installinfo
++#	dh_installman
++#	dh_link
++#	dh_strip
++	dh_compress 
++#	dh_fixperms
++#	dh_perl
++#	dh_makeshlibs
++	dh_installdeb
++#	dh_shlibdeps
++	dh_gencontrol
++	dh_md5sums
++	dh_builddeb
++# Build architecture independant packages using the common target.
++binary-indep: build-indep install-indep
++	$(MAKE) -f debian/rules DH_OPTIONS=-i binary-common
++
++# Build architecture dependant packages using the common target.
++#binary-arch: build-arch install-arch
++#	$(MAKE) -f debian/rules DH_OPTIONS=-s binary-common
++
++binary: binary-arch binary-indep
++.PHONY: build clean binary-indep binary-arch binary install install-indep install-arch configure
+--- debian/control
++++ debian/control
+@@ -0,0 +1,36 @@
++Source: libkdtree++
++Section: libs
++Priority: optional
++Maintainer: Sebastian Ramacher <s.ramacher@gmx.at>
++Build-Depends: debhelper (>=5)
++Standards-Version: 3.8.0
++
++Package: libkdtree++-dev
++Section: libdevel
++Architecture: all
++Description: C++ template container implementation of kd-tree sorting
++ libkdtree++ is a C++ template container implementation of k-dimensional space
++ sorting, using a kd-tree. It:
++ .
++   - supports an unlimited number of dimensions (in theory)
++   - can store any data structure, provided the data structure provides
++     operator[0 - k-1] to access the individual dimensional
++     components (arrays, std::vector already do) and a std::less
++     implementation for the type of dimensional components
++   - has support for custom allocators
++   - implements iterators
++   - provides standard find as well as range queries
++   - has amortised O(lg n) time (O(n lg n) worst case) on most
++     operations (insert/erase/find optimised) and worst-case O(n) space
++   - provides a means to rebalance and thus optimise the tree
++   - exists in its own namespace
++   - uses STL coding style, basing a lot of the code on stl_tree.h
++ .
++ It's not yet documented, although the usage should be fairly straight
++ forward. I am hoping to find someone else to document it as I suck at
++ documentation and as the author, it's exceptionally difficult to stay
++ didactically correct.
++ .
++ libkdtree++ only exists as a -dev package as it's only a bunch of C++ header
++ files. Therefore, no static or shared library is necessary, allowing for
++ ultimate flexibility.
+--- debian/changelog
++++ debian/changelog
+@@ -0,0 +1,69 @@
++libkdtree++ (0.7.0-2) unstable; urgency=low
++
++  * New maintainer. (Closes: #689206)
++    Thanks to Martin Schreiber for maintaining libkdtree++!
++  * debian/copyright:
++    - List the copyright of the authors. (Closes: #688796)
++    - Mention the download location.
++    - List the Debian maintainers.
++    - Update URL of the Artistic License.
++  * debian/README.Debian: Document that this is a snapshot of 222b5d77 and not
++    0.7.0.
++
++ -- Sebastian Ramacher <s.ramacher@gmx.at>  Thu, 11 Oct 2012 21:24:38 +0200
++
++libkdtree++ (0.7.0-1.1) unstable; urgency=low
++
++  * Non-maintainer upload.
++  * Cherry pick 8d4fbb9a from upstream to fix issues with g++ 4.7. (Closes:
++    #687604)
++
++ -- Sebastian Ramacher <s.ramacher@gmx.at>  Tue, 25 Sep 2012 16:57:06 +0200
++
++libkdtree++ (0.7.0-1) unstable; urgency=low
++
++  * New upstream release (closes: Bug#506485)
++
++ -- Martin Schreiber <schreiberx@gmail.com>  Tue, 30 Dec 2008 10:34:06 +0100
++
++libkdtree++ (0.6.2-1) unstable; urgency=low
++
++  * New upstream version (closes: Bug#459106)
++  * New maintainer
++
++ -- Martin Schreiber <schreiberx@gmail.com>  Fri, 08 Feb 2008 22:52:21 +0100
++
++libkdtree++ (0.2.0-1) unstable; urgency=low
++
++  * New upstream version, thanks to Paul Harris.
++  * Closes bugs from 0.1.3-1, which was not officially uploaded to Debian
++    (closes: Bug#279614, Bug#279620).
++
++ -- martin f. krafft <madduck@debian.org>  Mon, 15 Nov 2004 09:40:36 +0100
++
++libkdtree++ (0.1.3-1) unstable; urgency=low
++
++  * New upstream version (closes: Bug#279614, Bug#279620).
++  * Pushed Standards-Version to 3.6.1.1
++
++ -- martin f. krafft <madduck@debian.org>  Thu,  4 Nov 2004 10:29:23 +0100
++
++libkdtree++ (0.1.2-1) unstable; urgency=low
++
++  * Added note about lack of runtime and shared libraries.
++  * Changed licence to the artistic licence.
++
++ -- martin f. krafft <madduck@debian.org>  Sun, 16 May 2004 00:52:10 +0200
++
++libkdtree++ (0.1.1-1) unstable; urgency=low
++
++  * New upstream release.
++
++ -- martin f. krafft <madduck@debian.org>  Tue, 11 May 2004 19:48:32 +0200
++
++libkdtree++ (0.1.0-1) unstable; urgency=low
++
++  * Initial Release. (closes: Bug#248219)
++
++ -- martin f. krafft <madduck@debian.org>  Tue, 11 May 2004 15:49:02 +0200
++
+--- debian/libkdtree++-dev.install
++++ debian/libkdtree++-dev.install
+@@ -0,0 +1 @@
++usr/include/kdtree++/*
+--- debian/.cvsignore
++++ debian/.cvsignore
+@@ -0,0 +1,3 @@
++files
++libkdtree++-dev
++tmp
+--- debian/compat
++++ debian/compat
+@@ -0,0 +1 @@
++4
+--- debian/README.Debian
++++ debian/README.Debian
+@@ -0,0 +1,11 @@
++Notes on 0.7.0
++--------------
++
++The version shipped as 0.7.0 in Debian isn't actually the official 0.7.0
++release. It's a snapshot of 222b5d77 that can be downloaded from
++http://anonscm.debian.org/gitweb/?p=libkdtree/libkdtree.git;a=commit;h=222b5d7.
++
++The version in Debian is missing the Python bindings and some changes to
++the ChangeLog and the cmake build system.
++
++ -- Sebastian Ramacher <s.ramacher@gmx.at>  Wed, 10 Oct 2012 22:34:05 +0200
+--- debian/copyright
++++ debian/copyright
+@@ -0,0 +1,192 @@
++This package was debianized by martin f. krafft <madduck@debian.org> on
++ Tue, 11 May 2004 15:49:02 +0200.
++
++It was adopted by Martin Schreiber <schreiberx@gmail.com> on
++ Fri, 08 Feb 2008 22:52:21 +0100.
++
++The current Debian maintainer is Sebastian Ramacher <s.ramacher@gmx.at>.
++
++It was downloaded from https://alioth.debian.org/frs/?group_id=31203
++
++Upstream Authors: Martin F. Krafft, Paul Harris, Sylvain Bougerel
++
++Copyright: 2004-2007 Martin F. Krafft
++           2004-2007 Paul Harris
++           2007-2008 Sylvain Bougerel
++
++"The Artistic Licence 2.0"
++Copyright (c) 2000-2006, The Perl Foundation.
++http://www.perlfoundation.org/artistic_license_2_0
++
++Everyone is permitted to copy and distribute verbatim copies of this license
++document, but changing it is not allowed.
++
++Preamble
++~~~~~~~~
++This license establishes the terms under which a given free software Package
++may be copied, modified, distributed, and/or redistributed. The intent is that
++the Copyright Holder maintains some artistic control over the development of
++that Package while still keeping the Package available as open source and free
++software.
++
++You are always permitted to make arrangements wholly outside of this license
++directly with the Copyright Holder of a given Package. If the terms of this
++license do not permit the full use that you propose to make of the Package,
++you should contact the Copyright Holder and seek a different licensing
++arrangement.
++
++Definitions
++~~~~~~~~~~~
++"Copyright Holder" means the individual(s) or organization(s) named in the
++copyright notice for the entire Package.
++
++"Contributor" means any party that has contributed code or other material to
++the Package, in accordance with the Copyright Holder's procedures.
++
++"You" and "your" means any person who would like to copy, distribute, or
++modify the Package.
++
++"Package" means the collection of files distributed by the Copyright Holder,
++and derivatives of that collection and/or of those files. A given Package may
++consist of either the Standard Version, or a Modified Version.
++
++"Distribute" means providing a copy of the Package or making it accessible to
++anyone else, or in the case of a company or organization, to others outside of
++your company or organization.
++
++"Distributor Fee" means any fee that you charge for Distributing this Package
++or providing support for this Package to another party. It does not mean
++licensing fees.
++
++"Standard Version" refers to the Package if it has not been modified, or has
++been modified only in ways explicitly requested by the Copyright Holder.
++
++"Modified Version" means the Package, if it has been changed, and such changes
++were not explicitly requested by the Copyright Holder.
++
++"Original License" means this Artistic License as Distributed with the
++Standard Version of the Package, in its current version or as it may be
++modified by The Perl Foundation in the future.
++
++"Source" form means the source code, documentation source, and configuration
++files for the Package.
++
++"Compiled" form means the compiled bytecode, object code, binary, or any other
++form resulting from mechanical transformation or translation of the Source
++form.
++
++Permission for Use and Modification Without Distribution
++~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
++(1) You are permitted to use the Standard Version and create and use Modified
++Versions for any purpose without restriction, provided that you do not
++Distribute the Modified Version.
++
++Permissions for Redistribution of the Standard Version
++~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
++(2) You may Distribute verbatim copies of the Source form of the Standard
++Version of this Package in any medium without restriction, either gratis or
++for a Distributor Fee, provided that you duplicate all of the original
++copyright notices and associated disclaimers. At your discretion, such
++verbatim copies may or may not include a Compiled form of the Package.
++
++(3) You may apply any bug fixes, portability changes, and other modifications
++made available from the Copyright Holder. The resulting Package will still be
++considered the Standard Version, and as such will be subject to the Original
++License.
++
++Distribution of Modified Versions of the Package as Source
++~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
++(4) You may Distribute your Modified Version as Source (either gratis or for
++a Distributor Fee, and with or without a Compiled form of the Modified
++Version) provided that you clearly document how it differs from the Standard
++Version, including, but not limited to, documenting any non-standard features,
++executables, or modules, and provided that you do at least ONE of the
++following:
++
++    (a) make the Modified Version available to the Copyright Holder of the
++        Standard Version, under the Original License, so that the Copyright
++        Holder may include your modifications in the Standard Version.
++    (b) ensure that installation of your Modified Version does not prevent the
++        user installing or running the Standard Version. In addition, the
++        Modified Version must bear a name that is different from the name of
++        the Standard Version.
++    (c) allow anyone who receives a copy of the Modified Version to make the
++        Source form of the Modified Version available to others under
++        (i) the Original License or
++        (ii) a license that permits the licensee to freely copy, modify and
++             redistribute the Modified Version using the same licensing terms
++             that apply to the copy that the licensee received, and requires
++             that the Source form of the Modified Version, and of any works
++             derived from it, be made freely available in that license fees
++             are prohibited but Distributor Fees are allowed.
++
++Distribution of Compiled Forms of the Standard Version or Modified Versions
++without the Source
++~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
++(5) You may Distribute Compiled forms of the Standard Version without the
++Source, provided that you include complete instructions on how to get the
++Source of the Standard Version. Such instructions must be valid at the time of
++your distribution. If these instructions, at any time while you are carrying
++out such distribution, become invalid, you must provide new instructions on
++demand or cease further distribution. If you provide valid instructions or
++cease distribution within thirty days after you become aware that the
++instructions are invalid, then you do not forfeit any of your rights under
++this license.
++
++(6) You may Distribute a Modified Version in Compiled form without the Source,
++provided that you comply with Section 4 with respect to the Source of the
++Modified Version.
++
++Aggregating or Linking the Package
++~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
++(7) You may aggregate the Package (either the Standard Version or Modified
++Version) with other packages and Distribute the resulting aggregation provided
++that you do not charge a licensing fee for the Package. Distributor Fees are
++permitted, and licensing fees for other components in the aggregation are
++permitted. The terms of this license apply to the use and Distribution of the
++Standard or Modified Versions as included in the aggregation.
++
++(8) You are permitted to link Modified and Standard Versions with other works,
++to embed the Package in a larger work of your own, or to build stand-alone
++binary or bytecode versions of applications that include the Package, and
++Distribute the result without restriction, provided the result does not expose
++a direct interface to the Package.
++
++Items That are Not Considered Part of a Modified Version
++~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
++(9) Works (including, but not limited to, modules and scripts) that merely
++extend or make use of the Package, do not, by themselves, cause the Package to
++be a Modified Version. In addition, such works are not considered parts of the
++Package itself, and are not subject to the terms of this license.
++
++General Provisions
++~~~~~~~~~~~~~~~~~~
++(10) Any use, modification, and distribution of the Standard or Modified
++Versions is governed by this Artistic License. By using, modifying or
++distributing the Package, you accept this license. Do not use, modify, or
++distribute the Package, if you do not accept this license.
++
++(11) If your Modified Version has been derived from a Modified Version made by
++someone other than you, you are nevertheless required to ensure that your
++Modified Version complies with the requirements of this license.
++
++(12) This license does not grant you the right to use any trademark, service
++mark, tradename, or logo of the Copyright Holder.
++
++(13) This license includes the non-exclusive, worldwide, free-of-charge patent
++license to make, have made, use, offer to sell, sell, import and otherwise
++transfer the Package with respect to any patent claims licensable by the
++Copyright Holder that are necessarily infringed by the Package. If you
++institute patent litigation (including a cross-claim or counterclaim) against
++any party alleging that the Package constitutes direct or contributory patent
++infringement, then this Artistic License to you shall terminate on the date
++that such litigation is filed.
++
++(14) Disclaimer of Warranty: THE PACKAGE IS PROVIDED BY THE COPYRIGHT HOLDER
++AND CONTRIBUTORS "AS IS' AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES. THE
++IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OR
++NON-INFRINGEMENT ARE DISCLAIMED TO THE EXTENT PERMITTED BY YOUR LOCAL LAW.
++UNLESS REQUIRED BY LAW, NO COPYRIGHT HOLDER OR CONTRIBUTOR WILL BE LIABLE FOR
++ANY DIRECT, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES ARISING IN ANY WAY
++OUT OF THE USE OF THE PACKAGE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
++DAMAGE.
+--- debian/docs
++++ debian/docs
+@@ -0,0 +1,3 @@
++NEWS
++README
++TODO

--- a/source.yml
+++ b/source.yml
@@ -191,9 +191,9 @@ version_control:
 
     - external/kdtree:
         type: archive
-        url: http://ftp.de.debian.org/debian/pool/main/libk/libkdtree++/libkdtree++_0.7.0.orig.tar.gz
+        url: http://ftp.de.debian.org/debian/pool/main/libk/libkdtree++/libkdtree++_0.7.1+git20101123.orig.tar.xz
         update_cached_file: false
-        patches: $AUTOPROJ_SOURCE_DIR/patches/libkdtree++_0.7.0-2.diff
+        patches: $AUTOPROJ_SOURCE_DIR/patches/libkdtree++_0.7.1.diff
 
     - external/box2d:
         type: svn


### PR DESCRIPTION
This is the first part for updating Gentoo osdeps. My plan is to send the less involved rock.osdeps updates next, and finally changes involving slam/pcl, and how that package is responsible for setting the PKG_CONFIG_PATH for the install directory. Let me know if you want this handled in a different way.