### PR TITLE
define gui/orogen/qt_base

### DIFF
--- a/orogen.autobuild
+++ b/orogen.autobuild
@@ -16,6 +16,7 @@ orogen_package 'perception/orogen/depth_map_preprocessing'
 orogen_package 'slam/orogen/simple_pose_integrator'
 orogen_package 'control/orogen/robot_frames'
 orogen_package 'control/orogen/joint_tools'
+orogen_package 'gui/orogen/qt_base'
 
     in_flavor 'master' do
         orogen_package 'drivers/orogen/kinect2'


### PR DESCRIPTION
qt_base provides a component implementation with specific hooks
that are called within the Qt main thread instead of the RTT
thread, to follow Qt's own requirements.

Depends on:
- [ ] https://github.com/orocos-toolchain/orogen/pull/129
