### PR TITLE
do not build collada_osg on Ubuntu 20.04

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -589,3 +589,9 @@ jsoncpp:
 
 kontena-websocket-client:
     gem
+
+gui/collada_osg:
+    ubuntu:
+        "16.04,18.04,18.10,19.04,19.10": nonexistent
+        default:
+            osdep: osg # included in default packages


### PR DESCRIPTION
The OSG 3.4 packages include the plugin, so there's no need
to build it separately.
