### PR TITLE
Update eigen3 patch. Account for cmake changes in orocos_kdl.

### DIFF
--- a/patches/orocos_kdl_eigen_v3.patch
+++ b/patches/orocos_kdl_eigen_v3.patch
@@ -1,0 +1,18 @@
+--- a/orocos_kdl/CMakeLists.txt
++++ b/orocos_kdl/CMakeLists.txt
+@@ -45,12 +45,13 @@ ENDIF ( NOT CMAKE_BUILD_TYPE )
+
+ SET( KDL_CFLAGS "")
+
+-find_package(Eigen3 QUIET)
+-if(NOT EIGEN3_FOUND)
+-  include(${PROJ_SOURCE_DIR}/cmake/FindEigen3.cmake)
++rock_find_pkgconfig(Eigen 3.0 QUIET)
++if(NOT Eigen_FOUND)
++   include(${PROJ_SOURCE_DIR}/cmake/FindEigen3.cmake)
++   set(EIGEN_INCLUDE_DIR ${EIGEN3_INCLUDE_DIR})
+ endif()
+-include_directories(${EIGEN3_INCLUDE_DIR})
+-SET(KDL_CFLAGS "${KDL_CFLAGS} -I${EIGEN3_INCLUDE_DIR}")
++include_directories(${EIGEN_INCLUDE_DIR})
++SET(KDL_CFLAGS "${KDL_CFLAGS} -I${EIGEN_INCLUDE_DIR}")

--- a/source.yml
+++ b/source.yml
@@ -218,7 +218,7 @@ version_control:
         branch: master
         patches:
             - $AUTOPROJ_SOURCE_DIR/patches/orocos_kdl.patch
-            - [$AUTOPROJ_SOURCE_DIR/patches/orocos_kdl_eigen_v2.patch, 1]
+            - [$AUTOPROJ_SOURCE_DIR/patches/orocos_kdl_eigen_v3.patch, 1]
 
     - drivers/imu_myahrs_plus:
         type: git


### PR DESCRIPTION
Due to recent changes of the CMakeLists.txt in the [orocos repo](https://github.com/orocos/orocos_kinematics_dynamics/commit/228754b67123f9568cb21998ec1bebaae7e46ddb#diff-afd1f68b101d292e1f61c6b8dab773ae) the orocos_kdl_eigen patch required an update.