### PR TITLE
WiP: Change source of planning/fast_downward

### DIFF
--- a/source.yml
+++ b/source.yml
@@ -153,11 +153,9 @@ version_control:
         tag: pcl-1.7.1
 
     - planning/fast_downward:
-        type: archive
-        url: http://hg.fast-downward.org/archive/4d52652adfee.tar.gz/src
-        filename: fastdownward-4d52652adfee.tar.gz
-        patches: $AUTOPROJ_SOURCE_DIR/patches/fast_downward.patch
-        update_cached_file: false
+        type: hg
+        url: http://hg.fast-downward.org
+        branch: 4d52652adfee
 
     - planning/randward:
         github: rock-planning/planning-$PACKAGE_BASENAME


### PR DESCRIPTION
Looks like the tar.gz is not available anymore.

Now use hg directly with commit pinning
