### PR TITLE
gui/robot_model: fix setting of VIZKIT_PLUGIN_RUBY_PATH

### DIFF
--- a/libs.autobuild
+++ b/libs.autobuild
@@ -312,6 +312,7 @@ in_flavor 'master', 'stable' do
     cmake_package 'control/kdl_parser'
     cmake_package 'control/robot_frames'
     cmake_package 'gui/robot_model' do |pkg|
+        pkg.env_add_path "VIZKIT_PLUGIN_RUBY_PATH", File.join(pkg.prefix,"lib")
         # the tests in gui/robot_model is an app for a human to run. Do not let
         # autoproj believe there is something to run automatically
         pkg.test_utility.available = false


### PR DESCRIPTION
Testing for the upcoming debian package release exposed a missing environment setting for gui/robot_model:

```
Traceback (most recent call last):
	5: from /opt/rock/master-20.06/rock-master-20.06-gui-robot-model/bin/rock-roboviz:197:in `<main>'
	4: from /opt/rock/master-20.06/rock-master-20.06-ruby-gui-vizkit/lib/ruby/vendor_ruby/vizkit/plugin_accessor.rb:40:in `block in add_plugin_spec'
	3: from /opt/rock/master-20.06/rock-master-20.06-ruby-gui-vizkit/lib/ruby/vendor_ruby/vizkit/uiloader.rb:341:in `create_plugin'
	2: from /opt/rock/master-20.06/rock-master-20.06-ruby-gui-vizkit/lib/ruby/vendor_ruby/vizkit/plugin.rb:549:in `create_plugin'
	1: from /opt/rock/master-20.06/rock-master-20.06-ruby-gui-vizkit/lib/ruby/vendor_ruby/vizkit/uiloader.rb:46:in `block in register_3d_plugin'
/opt/rock/master-20.06/rock-master-20.06-ruby-gui-vizkit/lib/ruby/vendor_ruby/vizkit/cplusplus_extensions/vizkit_widget.rb:239:in `createPlugin': cannot find librobot_model-viz.so in VIZKIT_PLUGIN_RUBY_PATH. (RuntimeError)
```

