### PR TITLE
slam/gtsam: update to github repository and switch to 4.1rc

### DIFF
--- a/source.yml
+++ b/source.yml
@@ -274,12 +274,8 @@ version_control:
         tag: 1.13.0
 
     - slam/gtsam:
-        type: git
-        url: https://bitbucket.org/gtborg/gtsam.git
-        push_to: git@bitbucket.org:gtborg/gtsam.git
-        push_url: https://bitbucket.org/gtborg/gtsam.git
-        repository_id: https://bitbucket.org/gtborg/gtsam.git
-        tag: 4.0.0-alpha1
+        github: borglab/gtsam
+        tag: 4.1rc
         patches:
             - $AUTOPROJ_SOURCE_DIR/patches/gtsam.patch
 


### PR DESCRIPTION
Switch to 4.1rc, since 4.0.0-alpha1 did not built due to missing includes