### PR TITLE
Remove libqwt5-qt4-dev for Ubuntu 20.04

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -202,7 +202,9 @@ osgEarth:
     opensuse: nonexistent
 
 qwt5:
-    debian,ubuntu: libqwt5-qt4-dev
+    debian,ubuntu: 
+        default: libqwt5-qt4-dev
+        '20.04': nonexistent
     fedora,opensuse: qwt-devel
     darwin: qwt
     arch: qwt5


### PR DESCRIPTION
 The library named above is not available in Ubuntu 20.04 anymore and is not provided via the qt4 backports.