### PR TITLE
Remove qwt5 osdep as it is already defined in rock-package_set

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -201,15 +201,6 @@ osgEarth:
     fedora: nonexistent
     opensuse: nonexistent
 
-qwt5:
-    debian,ubuntu: 
-        default: libqwt5-qt4-dev
-        '20.04': nonexistent
-    fedora,opensuse: qwt-devel
-    darwin: qwt
-    arch: qwt5
-    gentoo: x11-libs/qwt
-
 qsqlite:
     debian,ubuntu: libqt4-sql-sqlite
     fedora: qt-devel


### PR DESCRIPTION
`WARN: osdeps definition for qwt5, previously defined in /home/user/rock/autoproj/remotes/rock.core/rock.osdeps overridden by /home/user/rock/autoproj/remotes/rock/rock.osdeps`

The qwt5 osdep is defined in multiple package sets. I would suggest to remove it here and consolidate it with the definition in the core package set.
