### PR TITLE
Organize python osdeps in version specific files

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -25,10 +25,6 @@ sysfs:
     arch,manjarolinux: sysfsutils
     opensuse: [sysfsutils-devel, sysfsutils]
 
-scipy:
-    debian,ubuntu: python-scipy
-    opensuse: python-scipy
-
 ode:
     debian,ubuntu: libode-dev
     # opensuse: [libode1, libode-devel] # available in repository games
@@ -36,10 +32,6 @@ ode:
 soqt:
     debian,ubuntu: libsoqt4-dev
     # opensuse: SoQt-devel # available in repository Packman
-
-sympy:
-    debian,ubuntu: python-sympy
-    opensuse: python-sympy
 
 assimp:
     debian,ubuntu: libassimp-dev
@@ -372,14 +364,6 @@ tools/rbind:
     gem: rbind
     debian,ubuntu: libffi-dev
     opensuse: libffi-devel
-
-numpy:
-    debian, ubuntu: python-numpy
-    opensuse: python-numpy
-
-cython:
-    debian, ubuntu: cython
-    opensuse: python-Cython
 
 unzip:
     debian, ubuntu: unzip

--- a/rock.osdeps-python2
+++ b/rock.osdeps-python2
@@ -1,0 +1,11 @@
+numpy:
+    debian, ubuntu: python-numpy
+    opensuse: python-numpy
+
+scipy:
+    debian,ubuntu: python-scipy
+    opensuse: python-scipy
+
+sympy:
+    debian,ubuntu: python-sympy
+    opensuse: python-sympy

--- a/rock.osdeps-python3
+++ b/rock.osdeps-python3
@@ -1,0 +1,11 @@
+numpy:
+    debian, ubuntu: python3-numpy
+    opensuse: python3-numpy
+
+scipy:
+    debian,ubuntu: python3-scipy
+    opensuse: python3-scipy
+
+sympy:
+    debian,ubuntu: python3-sympy
+    opensuse: python3-sympy


### PR DESCRIPTION
Cython definition for python2 will be moved to rock.core package set for consistency reasons