### PR TITLE
libqglviewer-dev-qt4 is not available in 20.04 (even with rock-core ppa)

### DIFF
--- a/manifests/slam/g2o.xml
+++ b/manifests/slam/g2o.xml
@@ -13,7 +13,7 @@
     <license>LGPL v.3</license>
     <url>http://www.openslam.org/g2o.html</url>
     <depend package="eigen3" />
-    <depend package="libqglviewer" />
+    <depend package="libqglviewer" optional="1" />
     <depend package="cholmod" optional="1" />
     <depend package="lapack" optional="1" />
     <depend package="csparse" optional="1" />

--- a/manifests/slam/octomap.xml
+++ b/manifests/slam/octomap.xml
@@ -32,6 +32,6 @@
   </description>
   <license>New BSD</license>
   <url>http://octomap.github.io/</url>
-  <depend package="qt4-opengl" />
-  <depend package="libqglviewer" />
+  <depend package="qt4-opengl" optional="1"/>
+  <depend package="libqglviewer" optional="1"/>
 </package>

--- a/rock.osdeps
+++ b/rock.osdeps
@@ -351,6 +351,7 @@ libqglviewer:
     ubuntu:
         '12.04,12.10,13.04': libqglviewer-qt4-dev
         '14.04,14.10,15.04,15.10': libqglviewer-dev
+        '20.04': nonexistent
         default: libqglviewer-dev-qt4
     debian:
         '7.3':   libqglviewer-qt4-dev


### PR DESCRIPTION
mark it nonexistent instead making it qt5 to make in impossible to link different qt versions when using the ppa.
It is only used optionally in slam/g2o and slam/octomap so make those deps optional (extra viz tools)

The CI in use has a time limit for building. Hence, we require a particular branch naming schema for PRs, so that a single package build can be tested.

Use the following schema to trigger the build: `update__<name-of-your-package>`
For instance to add an oroGen package `drivers/orogen/new_driver`, create the following branch to create your PR: `update__drivers/orogen/new_driver`
