### PR TITLE
updated the url for drivers-imu_an_spatial

### DIFF
--- a/manifests/drivers/imu_an_spatial.xml
+++ b/manifests/drivers/imu_an_spatial.xml
@@ -1,0 +1,8 @@
+<package>
+  <description brief="Driver for imu_an_spatial">
+    Driver for imu_an_spatial
+  </description>
+  <author>Advanced Navigation</author>
+  <url>https://www.advancednavigation.com/solutions/spatial/#Software</url>
+  <depend package="base/cmake " />
+</package>

--- a/manifests/drivers/imu_an_spatial.xml
+++ b/manifests/drivers/imu_an_spatial.xml
@@ -4,5 +4,5 @@
   </description>
   <author>Advanced Navigation</author>
   <url>https://www.advancednavigation.com/solutions/spatial/#Software</url>
-  <depend package="base/cmake " />
+  <depend package="base/cmake" />
 </package>

--- a/source.yml
+++ b/source.yml
@@ -377,7 +377,7 @@ version_control:
 
     - drivers/imu_an_spatial:
         type: archive
-        url: https://www.advancednavigation.com/sites/default/files/product_software/spatialsdk.zip
+        url: https://www.advancednavigation.com/wp-content/uploads/2021/08/spatialsdk.zip
         no_subdirectory: true
         update_cached_file: true
         patches:


### PR DESCRIPTION
The [old URL](https://www.advancednavigation.com/sites/default/files/product_software/spatialsdk.zip) for importing the driver imu_an_spatial doesn't work anymore. I have updated the new URL in `source.yml`: https://www.advancednavigation.com/wp-content/uploads/2021/08/spatialsdk.zip
Please merge the pull request to update the link. 
