### PR TITLE
feat: define drivers/orogen/transforms

### DIFF
--- a/orogen.autobuild
+++ b/orogen.autobuild
@@ -1,6 +1,7 @@
 # IMPORTANT: new packages must be added at the top of this file (after if
 # package_enabled ...)
 
+orogen_package 'drivers/orogen/transforms'
 orogen_package 'drivers/orogen/imu_myahrs_plus'
 orogen_package 'planning/orogen/exploration'
 orogen_package 'drivers/orogen/canopen_master'


### PR DESCRIPTION
This package defines components that provide some useful transformations.
They are not defined in drivers/orogen/transformer because they actually
require drivrs/orogen/transformer to be installed (for its orogen plugin)
