### PR TITLE
use gecode 6.3.0

### DIFF
--- a/source.yml
+++ b/source.yml
@@ -444,7 +444,7 @@ version_control:
 
     - tools/gecode:
         github: Gecode/gecode
-        tag: release-6.2.0
+        branch: release/6.3.0
 
     - tools/graph_analysis:
         github: rock-core/tools-graph_analysis


### PR DESCRIPTION
The integration tests of knowledge_reasoning/moreorg and planning/templ pass, after some minor adjustments in planning/templ due to newer compilers being more strict with ambiguities. On the other hand, even newer compilers can now compile gecode again.