### PR TITLE
Pin planning/fast_downward to one commit before they require c++20

### DIFF
--- a/source.yml
+++ b/source.yml
@@ -156,7 +156,11 @@ version_control:
         type: git
         github: aibasel/downward
         patches: $AUTOPROJ_SOURCE_DIR/patches/fast_downward.patch
-        branch: main
+        #branch: main
+        # pinned to the last commit before they require c++20
+        # (available starting with gcc-10 and clang-12, which are not
+        # available in ubuntu 18.04, not default in 20.04)
+        commit: fe473a2011c84f9082068a30fae8653e3823ea7f
 
     - planning/randward:
         github: rock-planning/planning-$PACKAGE_BASENAME


### PR DESCRIPTION
The package planning/fast_downward starts to require c++-20 with commit [c9d36f76](https://github.com/aibasel/downward/commit/c9d36f76cdc9ad5757f32a0b4ef79e4ec0c54505). Last "good" is [fe473a20](https://github.com/aibasel/downward/commit/fe473a2011c84f9082068a30fae8653e3823ea7f). Ubuntu 20.04 by default installs gcc-9(which lacks c++-20 support) by default, but can install gcc-10(which would support c++-20). ubuntu-18.04 only installs up to gcc-8. This PR to pins planning/fast_downward at fe473a20. That can be changed again once gcc-10 is installed by default on ubuntu 20.04 or 22.04 becomes usable.