### PR TITLE
feat: define drivers/gstreamer_helpers

### DIFF
--- a/libs.autobuild
+++ b/libs.autobuild
@@ -626,4 +626,6 @@ end
 # Don't build unless really really needed
 remove_from_default 'multiagent/fipa_acl'
 
+cmake_package "drivers/gstreamer_helpers"
+
 create_metapackages


### PR DESCRIPTION
The package will contain conversion helpers as well as pipeline management helpers from/to gstreamer for Rock. It is extracted from the existing drivers/orogen/gstreamer package.

The CI in use has a time limit for building. Hence, we require a particular branch naming schema for PRs, so that a single package build can be tested.

Use the following schema to trigger the build: `update__<name-of-your-package>`
For instance to add an oroGen package `drivers/orogen/new_driver`, create the following branch to create your PR: `update__drivers/orogen/new_driver`
