### PR TITLE
add hiredis database connector

### DIFF
--- a/libs.autobuild
+++ b/libs.autobuild
@@ -1,5 +1,7 @@
 #800 IMPORTANT: new packages must be added at the top of this file
 
+cmake_package "database/redis/hiredis"
+
 cmake_package 'slam/pclomp'
 cmake_package 'slam/slam3d' do |pkg|
     pkg.define 'BUILD_SHARED_LIBS', 'TRUE'

--- a/source.yml
+++ b/source.yml
@@ -251,6 +251,9 @@ version_control:
         github: rock-data-processing/data_processing-orogen-$PACKAGE_BASENAME
         branch: $ROCK_BRANCH
 
+    - database/redis/hiredis:
+      github: redis/hiredis
+
     - drivers/aria:
         type: archive
         url: http://robots.mobilerobots.com/ARIA/download/archives/ARIA-2.7.5+gcc4.3.tgz


### PR DESCRIPTION
Add the "hiredis" redis database client. (Used for the database version of the slam3d package)