### PR TITLE
Replace deprecated Autoproj.configuration_option by Autoproj.config.declare

### DIFF
--- a/libs.autobuild
+++ b/libs.autobuild
@@ -208,7 +208,7 @@ in_flavor 'master' do
         # Seamlessly migrate from the SVN to the archive. We must delete the svn
         # directory !
         if pkg.importer.kind_of?(Autobuild::ArchiveImporter) && File.directory?(File.join(pkg.srcdir, ".git"))
-            Autoproj.configuration_option "UPDATE_VISO2_FROM_GIT", "boolean",
+            Autoproj.config.declare "UPDATE_VISO2_FROM_GIT", "boolean",
                 :doc => ["delete perception/viso2 to update to a release tarball ?",
                     "Rock was previously checking out from a Git repository but just switched to",
                     "using the release tarball. Updating requires the deletion of the",
@@ -555,7 +555,7 @@ in_flavor 'master', 'stable' do
         # Seamlessly migrate from the SVN to the archive. We must delete the svn
         # directory !
         if pkg.importer.kind_of?(Autobuild::ArchiveImporter) && File.directory?(File.join(pkg.srcdir, ".svn"))
-            Autoproj.configuration_option "UPDATE_PCL_FROM_SVN", "boolean",
+            Autoproj.config.declare "UPDATE_PCL_FROM_SVN", "boolean",
                 :doc => ["delete slam/pcl to update to a release tarball ?",
                     "Rock was previously checking out the PCL SVN but just switched to",
                     "using the release tarball. Updating requires the deletion of the",


### PR DESCRIPTION
Deprecated according to https://github.com/rock-core/autoproj/blob/master/lib/autoproj/autobuild_extensions/dsl.rb#L453

Indirectly, this also fixes:

    warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call