### PR TITLE
Use File.exist instead of File.exists

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,7 +1,7 @@
 def has_ueye_api?
     include_file = File.join("/usr","include","ueye.h")
     lib = File.join("/usr","lib","libueye_api.so")
-    File.exists?(include_file) && File.exists?(lib)
+    File.exist?(include_file) && File.exist?(lib)
 end
 
 def create_metapackages


### PR DESCRIPTION
The CI in use has a time limit for building. Hence, we require a particular branch naming schema for PRs, so that a single package build can be tested.

Use the following schema to trigger the build: `update__<name-of-your-package>`
For instance to add an oroGen package `drivers/orogen/new_driver`, create the following branch to create your PR: `update__drivers/orogen/new_driver`
