### PR TITLE
Install planning/ompl as an OS-dependency

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -490,6 +490,12 @@ osgEarth:
     opensuse: nonexistent
     gentoo: nonexistent
 
+planning/ompl:
+    ubuntu:
+        '16.04,18.04': nonexistent  # did not check Ubuntu versions before 20.04
+        default: libompl-dev
+    default: nonexistent # did not check other distros
+
 png++:
     debian,ubuntu: libpng++-dev
     gentoo: media-libs/libpng


### PR DESCRIPTION
It appears unnecessary to build ompl from source.

I successfully build `planning/motion_planning_libraries` on Ubuntu 20 using the apt version of ompl (I made sure that the source code installation was uninstalled). Not sure if other libraries need a specific OMPL version or the patches we currently apply.