### PR TITLE
Remove (misleading) version number from libncurses5-dev package

### DIFF
--- a/rock.osdeps
+++ b/rock.osdeps
@@ -467,7 +467,7 @@ muparser:
     gentoo: dev-cpp/muParser
 
 ncurses:
-    debian,ubuntu: libncurses5-dev
+    debian,ubuntu: libncurses-dev
     gentoo: sys-libs/ncurses
     fedora,opensuse: ncurses-devel
     arch,manjarolinux: ncurses


### PR DESCRIPTION
According to 
https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=libncurses5-dev&searchon=names
https://packages.debian.org/search?suite=all&arch=any&searchon=names&keywords=libncurses5-dev
on both debian and Ubuntu, `libncurses5-dev` has long been only a transitional package for `libncurses-dev`.
At least on Ubuntu24.04 installing `libncurses5-dev` also works, but is triggered again for every osdep-update.