### PR TITLE
Use set_cmake_ruby_executable from rock.core for compatibility with CMake 3.16

### DIFF
--- a/libs.autobuild
+++ b/libs.autobuild
@@ -606,7 +606,7 @@ in_flavor 'master', 'stable' do
 
     #### Multiagent related packages
     cmake_package 'multiagent/fipa_acl' do |pkg|
-        pkg.define "RUBY_EXECUTABLE", Autoproj.config.ruby_executable
+        set_cmake_ruby_executable pkg
     end
 
     autotools_package 'external/kdtree'


### PR DESCRIPTION
This is analogue to https://github.com/rock-core/package_set/pull/251

Actually, this mostly needs to be merged into the `feature/qt4-qt5-cleanup2` branch
@pierrewillenbrockdfki shall I do that manually, or do we want to merge the entire master into that (maybe after this gets merged)?