### PR TITLE
fix: pin urdfdom and urdfdom_headers on versions compatible with CMake 3.16 (Ubuntu 20.04)

### DIFF
--- a/source.yml
+++ b/source.yml
@@ -80,10 +80,12 @@ version_control:
     - control/urdfdom_headers:
         github: ros/urdfdom_headers
         branch: rolling
+        tag: 2.0.0
 
     - control/urdfdom:
         github: ros/urdfdom
         branch: rolling
+        tag: 5.0.2
 
     - control/sdformat:
         type: archive


### PR DESCRIPTION
The CI in use has a time limit for building. Hence, we require a particular branch naming schema for PRs, so that a single package build can be tested.

Use the following schema to trigger the build: `update__<name-of-your-package>`
For instance to add an oroGen package `drivers/orogen/new_driver`, create the following branch to create your PR: `update__drivers/orogen/new_driver`
