### PR TITLE
Added build dependencies for slam3d.

### DIFF
--- a/libs.autobuild
+++ b/libs.autobuild
@@ -5,6 +5,8 @@ cmake_package "database/redis/hiredis"
 cmake_package 'slam/pclomp'
 cmake_package 'slam/slam3d' do |pkg|
     pkg.define 'BUILD_SHARED_LIBS', 'TRUE'
+    pkg.depends_on 'slam/pclomp'
+    pkg.depends_on 'slam/g2o'
 end
 
 cmake_package 'tools/udt'


### PR DESCRIPTION
The CI in use has a time limit for building. Hence, we require a particular branch naming schema for PRs, so that a single package build can be tested.

Use the following schema to trigger the build: `update__<name-of-your-package>`
For instance to add an oroGen package `drivers/orogen/new_driver`, create the following branch to create your PR: `update__drivers/orogen/new_driver`