### PR TITLE
Update packages for Ubuntu 24.04

### DIFF
--- a/gazebo.osrepos
+++ b/gazebo.osrepos
@@ -1,0 +1,7 @@
+- ubuntu:
+    - noble:  # Ubuntu 24.04 needs the gazebo package repository to install libsdformat
+        - type: repo
+          repo: deb http://packages.osrfoundation.org/gazebo/ubuntu-stable noble main
+        - type: key
+          keyserver: hkp://keyserver.ubuntu.com:80
+          id: 67170598AF249743

--- a/rock.osdeps
+++ b/rock.osdeps
@@ -106,7 +106,9 @@ control/sdformat:
     ubuntu:
         '14.04,14.10,15.04,15.10': nonexistent
         '16.04,16.10,17.04,17.10': libsdformat4-dev
-        default: libsdformat6-dev
+        '18.04,20.04': libsdformat6-dev
+        '24.04': libsdformat15-dev
+        default: libsdformat-dev
     debian:
         jessie,wheezy,squeeze: nonexistent
         stretch: libsdformat4-dev
@@ -378,6 +380,7 @@ libproc:
         '12.10,13.04,13.10': libprocps0-dev
         '14.04,14.10,15.04,15.10': libprocps3-dev
         '16.04': libprocps4-dev
+        '24.04': libproc2-dev
         default: libprocps-dev
     fedora,opensuse: procps-devel
     gentoo: sys-process/procps
@@ -509,7 +512,9 @@ proj:
     opensuse: [proj, libproj-devel]
 
 pypy:
-    ubuntu,debian: pypy
+    ubuntu,debian:
+      default: pypy
+      "24.04": pypy3
     gentoo: dev-python/pypy
 
 qhull:


### PR DESCRIPTION
These are some osdeps which need to be changed for Ubuntu 24.

* libsdformat unfortunately is not provided by Ubuntu 24 anymore. The easiest way I found to install it is via the gazebo repositories (building from source requires also downloading lots of dependencies just for their build-system).
Under Ubuntu 22 it is available as libsdformat-dev and installs version 12.3 (libsdformat6-dev actually links to version 12.3 as well)
* pypy does not exist anymore but pypy3 does
* libprocps-dev is replaced by libproc2-dev (this may not be completely compatible though)

For all packages I'm open for discussions which version/OS should be "default".
At some point we may also want to remove very old OS versions? (I doubt anyone has tested Ubuntu 14.04 recently ...)